### PR TITLE
Updated leinjacker version.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :dependencies [[analyze "0.1.6"]
                  [org.clojure/tools.namespace "0.1.2"]
                  [org.clojars.brenton/google-diff-match-patch "0.1"]
-                 [leinjacker "0.1.0"]]
+                 [leinjacker "0.4.1"]]
   :eval-in-leiningen true)


### PR DESCRIPTION
Updates the leinjacker version to 0.4.1. Without this, I get a crash on using eastwood.

Exception in thread "main" java.lang.AssertionError: Assert failed: (vector? (:dependencies project []))
    at leinjacker.deps$add_if_missing.invoke(deps.clj:43)
    at leiningen.eastwood$eastwood.invoke(eastwood.clj:17)
    at leiningen.eastwood$eastwood.invoke(eastwood.clj:6)
