### PR TITLE
Unused no longer reports vars refered to directly as unused.

### DIFF
--- a/src/eastwood/linters/unused.clj
+++ b/src/eastwood/linters/unused.clj
@@ -13,7 +13,7 @@
 
 (defn- var-freq [exprs]
   (->> (mapcat expr-seq exprs)
-       (filter #(= :var (:op %)))
+       (filter #(contains? #{:var :the-var} (:op %)))
        (map :var)
        frequencies))
   


### PR DESCRIPTION
Previously, only vars resolved from symbols were seen as being
in use. This fixes #4.
