### PR TITLE
Move namespace of eval-in-project due to deprecation warning.

### DIFF
--- a/src/leiningen/eastwood.clj
+++ b/src/leiningen/eastwood.clj
@@ -1,5 +1,5 @@
 (ns leiningen.eastwood
-  (:use [leinjacker.eval-in-project :only [eval-in-project]]
+  (:use [leinjacker.eval :only [eval-in-project]]
         [leinjacker.deps :only [add-if-missing]]))
 
 (defn eastwood


### PR DESCRIPTION
This just reflects a name change in leinjacker.
