### PR TITLE
:suspcious-expression should not look into quoted expressions

### DIFF
--- a/src/eastwood/linters/typos.clj
+++ b/src/eastwood/linters/typos.clj
@@ -68,7 +68,7 @@
 ;                           (-> (first asts) :env :ns the-ns)))
         forms (util/string->forms source this-ns false)
         freqs (->> forms
-                   util/replace-comments-with-nil
+                   util/replace-comments-and-quotes-with-nil
                    flatten-also-colls
                    (filter keyword?)
                    frequencies)]
@@ -389,7 +389,7 @@ generate varying strings while the test is running."
   (apply
    concat
    (let [fs (-> forms
-                util/replace-comments-with-nil
+                util/replace-comments-and-quotes-with-nil
                 (util/subforms-with-first-in-set
                  (set (keys core-first-vars-that-do-little))))]
      (for [f fs]

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -245,8 +245,8 @@ http://dev.clojure.org/jira/browse/CLJ-1445"
                form))
            form))
 
-(defn replace-comments-with-nil [form]
-  (replace-subforms-with-first-in-set form #{'comment} (constantly nil)))
+(defn replace-comments-and-quotes-with-nil [form]
+  (replace-subforms-with-first-in-set form #{'comment 'quote} (constantly nil)))
 
 (defn- mark-statements-in-try-body-post [ast]
   (if (and (= :try (:op ast))


### PR DESCRIPTION
I had some data expressions that sort of looked like code which caused spurious warnings from :suspicious-expression.  My solution was to avoid linting any form inside a quote.  I used the same mechanism that handled 'comment'.  Please feel free to refactor as appropriate.  I did not study the code too deeply.
