### PR TITLE
Add vim-eastwood mention in editors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,10 @@ The warnings tend to be longer than one screen width.  You can use
 previous.  See the Vim documentation for more details,
 e.g. [here](http://vimdoc.sourceforge.net/htmldoc/quickfix.html).
 
+If you have [Syntastic](https://github.com/scrooloose/syntastic) and 
+[vim-fireplace](https://github.com/tpope/vim-fireplace/) installed,
+you can use [vim-eastwood](https://github.com/venantius/vim-eastwood)
+to automatically run Eastwood on the namespace in your current buffer.
 
 ### How the Eastwood options map is determined
 

--- a/README.next.md
+++ b/README.next.md
@@ -567,6 +567,10 @@ The warnings tend to be longer than one screen width.  You can use
 previous.  See the Vim documentation for more details,
 e.g. [here](http://vimdoc.sourceforge.net/htmldoc/quickfix.html).
 
+If you have [Syntastic](https://github.com/scrooloose/syntastic) and 
+[vim-fireplace](https://github.com/tpope/vim-fireplace/) installed,
+you can use [vim-eastwood](https://github.com/venantius/vim-eastwood)
+to automatically run Eastwood on the namespace in your current buffer.
 
 ### How the Eastwood options map is determined
 


### PR DESCRIPTION
I've written a [plugin](https://github.com/venantius/vim-eastwood) that automatically runs `eastwood.lint/eastwood` on the current Vim buffer through a vim-fireplace REPL connection, and offers Syntastic bindings. It'd be great if this could be linked to from the Eastwood README. Happy to make tweaks or adjustments if needed.