### PR TITLE
Disable constant-test in expansion of clojure.test/is

### DIFF
--- a/resource/eastwood/config/clojure.clj
+++ b/resource/eastwood/config/clojure.clj
@@ -32,3 +32,13 @@
   :within-depth 3
   :reason "when-some with an empty body is warned about, so warning about let with an empty body in its macroexpansion is redundant."})
 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Configs to disable warnings in clojure.test, version 1.6.0
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(disable-warning
+ {:linter :constant-test
+  :if-inside-macroexpansion-of #{'clojure.test/is}
+  :within-depth 1
+  :reason "The is macro commonly expands to contain an if with a condition that is a constant."})


### PR DESCRIPTION
I discovered this running Eastwood against [cider-nrepl](https://github.com/clojure-emacs/cider-nrepl).

A form like this:

``` clojure
(is (= (:status val) #{:done}))
```

gets expanded into something like this:

``` clojure
(if
 temp__4090__auto__
 (clojure.core/let
  [more__35__auto__ temp__4090__auto__]
  (clojure.core/let
   [result__36__auto__
    (clojure.core/apply clojure.core/= a__34__auto__ more__35__auto__)]
   (if
    result__36__auto__
    (clojure.test/do-report
     {:actual more__35__auto__,
      :type :pass,
      :message nil,
      :expected a__34__auto__})
    (clojure.test/do-report
     {:diffs
      (clojure.core/map
       clojure.core/vector
       more__35__auto__
       (clojure.core/map
        (fn*
         [p1__33__37__auto__]
         (clojure.core/take
          2
          (clojure.data/diff a__34__auto__ p1__33__37__auto__)))
        more__35__auto__)),
      :actual more__35__auto__,
      :type :fail,
      :message nil,
      :expected a__34__auto__}))
   result__36__auto__))
 (throw (java.lang.Exception. "= expects more than one argument")))
```

where `temp__4090__auto__` is equal to `(clojure.core/seq (clojure.core/list #{:done}))`, so the outermost `if` always goes down the `then` branch, and Eastwood warns:

`test/cider/nrepl/middleware/macroexpand_test.clj:105:7: constant-test: Test expression is always logical true or always logical false`

I've verified that adding this causes the above test to not warn, but the below still will:

``` clojure`
(is (= (if true 1 2) 1))
```
