### PR TITLE
Add middleware to store eastwood options in namespace var

### DIFF
--- a/src/eastwood/config.clj
+++ b/src/eastwood/config.clj
@@ -1,0 +1,3 @@
+(ns eastwood.config)
+
+(def options {})

--- a/src/eastwood/plugin.clj
+++ b/src/eastwood/plugin.clj
@@ -4,11 +4,7 @@
 
 (defn middleware
   [project]
-  (let [opts (:eastwood project)]
-    (leval/eval-in-project 
-      project
-      (intern
-        'eastwood.config
-        'options
-        opts))
-  project))
+  (let [opts (or (:eastwood project) {})]
+    (update-in project [:injections] concat
+               `[(require 'eastwood.config)
+                 (intern 'eastwood.config '~'options ~opts)])))

--- a/src/eastwood/plugin.clj
+++ b/src/eastwood/plugin.clj
@@ -1,0 +1,14 @@
+(ns eastwood.plugin
+  (:require [eastwood.config :as config]
+            [eastwood.copieddeps.dep6.leinjacker.eval :as leval]))
+
+(defn middleware
+  [project]
+  (let [opts (:eastwood project)]
+    (leval/eval-in-project 
+      project
+      (intern
+        'eastwood.config
+        'options
+        opts))
+  project))


### PR DESCRIPTION
This commit adds leiningen middleware to store the project's
eastwood options in `eastwood.config/options`. This has the advantage
of allowing users and other developers building on top of Eastwood's
REPL functionality to have easy access to a user's eastwood options.

This PR addresses https://github.com/jonase/eastwood/issues/155
