### PR TITLE
Release candidate 0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2287,7 +2287,7 @@ your local Maven repository:
     $ cd path/to/eastwood
     $ lein install
 
-Then add `[jonase/eastwood "0.2.4-SNAPSHOT"]` (or whatever is the
+Then add `[jonase/eastwood "0.2.5-SNAPSHOT"]` (or whatever is the
 current version number in the defproject line of `project.clj`) to
 your `:plugins` vector in your `:user` profile, perhaps in your
 `$HOME/.lein/profiles.clj` file.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ thrown -- Leiningen 2.6.1 was released to fix that problem.  Merge the
 following into your `$HOME/.lein/profiles.clj` file:
 
 ```clojure
-{:user {:plugins [[jonase/eastwood "0.2.3"]] }}
+{:user {:plugins [[jonase/eastwood "0.2.4"]] }}
 ```
 
 To run Eastwood with the default set of lint warnings on all of the
@@ -422,7 +422,7 @@ in a production JVM process.
 Merge this into your project's `project.clj` file first:
 
 ```clojure
-:profiles {:dev {:dependencies [[jonase/eastwood "0.2.3" :exclusions [org.clojure/clojure]]]}}
+:profiles {:dev {:dependencies [[jonase/eastwood "0.2.4" :exclusions [org.clojure/clojure]]]}}
 ```
 
 Note: This should work even if you do not use Leiningen for your
@@ -640,7 +640,7 @@ can be used to modify this merging behavior.
 For example, if your user-wide `profiles.clj` file contains this:
 
 ```clojure
-{:user {:plugins [[jonase/eastwood "0.2.3"]]
+{:user {:plugins [[jonase/eastwood "0.2.4"]]
         :eastwood {:exclude-linters [:unlimited-use]
                    :debug [:time]}
         }}

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,28 @@
 # Change log for Eastwood
 
 
+## Changes from version 0.2.3 to 0.2.4
+
+No new linters.  Added initial support for .cljc files and reader
+conditionals.
+
+* Read .cljc files in addition to .clj files when scanning namespaces.
+
+* Handle reader conditionals by always parsing the :clj branch.
+
+* Allow ClojureScript-specific libspec entries, such as `:include-macros
+  true`.
+
+
+Internal enhancements:
+
+* Updated versions of tools.analyzer, tools.reader, tools.namespace,
+  core.memoize, and clojure.java.classpath.
+
+* Updated documentation, cleaned up comments, and removed unused
+  require statements.
+
+
 ## Changes from version 0.2.2 to 0.2.3
 
 No new linters.  The only difference with 0.2.2 is a few bug fixes:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jonase/eastwood "0.2.4-SNAPSHOT"
+(defproject jonase/eastwood "0.2.4"
   :description "A Clojure lint tool"
   :url "https://github.com/jonase/eastwood"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jonase/eastwood "0.2.4"
+(defproject jonase/eastwood "0.2.5-SNAPSHOT"
   :description "A Clojure lint tool"
   :url "https://github.com/jonase/eastwood"
   :license {:name "Eclipse Public License"

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -23,7 +23,7 @@
 (def eastwood-url "https://github.com/jonase/eastwood")
 
 (def ^:dynamic *eastwood-version*
-  {:major 0, :minor 2, :incremental 4, :qualifier "SNAPSHOT"})
+  {:major 0, :minor 2, :incremental 4})
 
 (defn eastwood-version []
   (let [{:keys [major minor incremental qualifier]} *eastwood-version*]

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -23,7 +23,7 @@
 (def eastwood-url "https://github.com/jonase/eastwood")
 
 (def ^:dynamic *eastwood-version*
-  {:major 0, :minor 2, :incremental 4})
+  {:major 0, :minor 2, :incremental 5, :qualifier "SNAPSHOT"})
 
 (defn eastwood-version []
   (let [{:keys [major minor incremental qualifier]} *eastwood-version*]

--- a/src/leiningen/eastwood.clj
+++ b/src/leiningen/eastwood.clj
@@ -3,7 +3,7 @@
             [eastwood.copieddeps.dep6.leinjacker.eval :as leval]
             [eastwood.copieddeps.dep6.leinjacker.deps :refer [add-if-missing]]))
 
-(def eastwood-version-string "0.2.4")
+(def eastwood-version-string "0.2.5-SNAPSHOT")
 
 ;; 'lein help' prints only the first line of the string returned by
 ;; help.  'lein help eastwood' prints all of it, plus the arg vectors

--- a/src/leiningen/eastwood.clj
+++ b/src/leiningen/eastwood.clj
@@ -3,7 +3,7 @@
             [eastwood.copieddeps.dep6.leinjacker.eval :as leval]
             [eastwood.copieddeps.dep6.leinjacker.deps :refer [add-if-missing]]))
 
-(def eastwood-version-string "0.2.4-SNAPSHOT")
+(def eastwood-version-string "0.2.4")
 
 ;; 'lein help' prints only the first line of the string returned by
 ;; help.  'lein help eastwood' prints all of it, plus the arg vectors


### PR DESCRIPTION
Here's what I propose for the 0.2.4 release. 35c48720c4f3be1b9ddec6d0b8b52fdde8fdb7d4 should be deployed, and the commit following that bumps version numbers to the next SNAPSHOT.

@jafingerhut, how does this look? Also, it looks like I can't deploy to clojars without "access to the 'jonase' group."