### PR TITLE
Support for custom linters

### DIFF
--- a/cases/custom_lints.clj
+++ b/cases/custom_lints.clj
@@ -1,0 +1,13 @@
+(ns custom-lints)
+
+(defn fake-linter
+  [analyze-results opts]
+  [{:linter :thing-linter
+    :msg "we linted something at testcases/custom.clj:1:1"
+    :file "testcases/custom.clj"
+    :line 1
+    :column 1}])
+
+(add-linter
+ {:name :thing-linter
+  :fn fake-linter})

--- a/cases/custom_lints.clj
+++ b/cases/custom_lints.clj
@@ -1,3 +1,7 @@
+(ns custom-lints
+  (:require [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
+            [eastwood.util :as util]))
+
 (defn custom-linter
   [analyze-results opts]
   (for [expr (mapcat ast/nodes (:asts analyze-results))
@@ -6,10 +10,10 @@
               s (.sym v)
               loc (:env expr)]
         :when (re-find #"custom" (name s))]
-    (add-loc-info loc
-                  {:linter :custom-linter
-                   :msg (format "%s shouldn't have the word 'custom'" v)})))
+    (util/add-loc-info loc
+                       {:linter :custom-linter
+                        :msg (format "%s shouldn't have the word 'custom'" v)})))
 
-(add-linter
+(util/add-linter
  {:name :custom-linter
   :fn custom-linter})

--- a/cases/testcases/custom.clj
+++ b/cases/testcases/custom.clj
@@ -1,0 +1,5 @@
+(ns testcases.custom)
+
+
+(defn custom-fn [data]
+  data)

--- a/crucible/README.txt
+++ b/crucible/README.txt
@@ -7,7 +7,7 @@ project-clj-files into some of the cloned repositories, in order to
 make running Eastwood on them possible.  It will also overwrite some
 existing project.clj files, so that they should all consistently use
 Clojure 1.5.1 by default, and have profiles named 1.5, 1.6, 1.7, 1.8,
-and 1.9, where 1.9 uses Clojure 1.9.0-master-SNAPSHOT.
+1.9, and 1.10, where 1.10 uses Clojure 1.10.0-master-SNAPSHOT.
 
 To build and install a copy of Clojure x.y.0-master-SNAPSHOT in your
 local $HOME/.m2 Maven repository, do this:

--- a/crucible/README.txt
+++ b/crucible/README.txt
@@ -6,8 +6,8 @@ This will also copy project.clj files from the directory
 project-clj-files into some of the cloned repositories, in order to
 make running Eastwood on them possible.  It will also overwrite some
 existing project.clj files, so that they should all consistently use
-Clojure 1.5.1 by default, and have profiles named 1.5, 1.6, 1.7, and
-1.8, where 1.8 uses Clojure 1.8.0-master-SNAPSHOT.
+Clojure 1.5.1 by default, and have profiles named 1.5, 1.6, 1.7, 1.8,
+and 1.9, where 1.9 uses Clojure 1.9.0-master-SNAPSHOT.
 
 To build and install a copy of Clojure x.y.0-master-SNAPSHOT in your
 local $HOME/.m2 Maven repository, do this:

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -1179,8 +1179,11 @@ Return value:
 
         ;; Changes below override anything in the caller-provided
         ;; options map.
-        opts (assoc opts :warning-enable-config
-                    (util/init-warning-enable-config opts))]
+        opts (assoc opts
+                    :warning-enable-config
+                    (util/init-warning-enable-config opts)
+                    :custom-linters-config
+                    (util/init-custom-linter-config opts))]
     opts))
 
 

--- a/test/eastwood/test/linters_test.clj
+++ b/test/eastwood/test/linters_test.clj
@@ -1874,3 +1874,17 @@ the next."
      default-opts
      {}))
   )
+
+
+(deftest custom-linters-test
+  (lint-test
+   'testcases.custom
+   []
+   (assoc default-opts
+          :lint-files [(io/resource "custom_lints.clj")])
+   {{:linter :thing-linter,
+     :msg "we linted something at testcases/custom.clj:1:1",
+     :file "testcases/custom.clj",
+     :line 1,
+     :column 1}
+    1}))

--- a/test/eastwood/test/linters_test.clj
+++ b/test/eastwood/test/linters_test.clj
@@ -1882,9 +1882,10 @@ the next."
    []
    (assoc default-opts
           :lint-files [(io/resource "custom_lints.clj")])
-   {{:linter :thing-linter,
-     :msg "we linted something at testcases/custom.clj:1:1",
+   {{:linter :custom-linter,
+     :msg
+     "#'testcases.custom/custom-fn shouldn't have the word 'custom'",
      :file "testcases/custom.clj",
-     :line 1,
+     :line 4,
      :column 1}
     1}))

--- a/test/eastwood/test/linters_test.clj
+++ b/test/eastwood/test/linters_test.clj
@@ -1881,7 +1881,7 @@ the next."
    'testcases.custom
    []
    (assoc default-opts
-          :lint-files [(io/resource "custom_lints.clj")])
+          :lint-files ["cases/custom_lints.clj"])
    {{:linter :custom-linter,
      :msg
      "#'testcases.custom/custom-fn shouldn't have the word 'custom'",


### PR DESCRIPTION
## What's this thing?

This PR allows Eastwood to load arbitrary linters from files in a project. Anyone using Eastwood can extend it with linters that are specific to their project, dev team, etc. Library authors could distribute Eastwood linters to their users as a set of guidelines.

Lots of cool options opened up by this :)

## How would it be used?

**Step one**, write some linters using `tools.analyzer`. Just to keep things organized, imagine a directory `linters` containing the files `company_styleguide.clj` and `security_practices.clj`.

**Step two**, within those files, call the new `add-linter` API referring to each of your new linters:

```clojure
(defn style-linter1 [analyze-results opts]
  ... )

(add-linter
  {:name style-linter1
   :fn style-linter1})

(defn style-linter2 [analyze-results opts]
  ... )

(add-linter
  {:name style-linter2
   :fn style-linter2})
```

 Any linters added by calling `add-linter` API will be added automatically to every invocation of Eastwood.

**Step three**, configure the new `:lint-files` option:

```clojure
{:eastwood {;;; existing Eastwood options
            :lint-files ["linters/company_styleguide.clj" "linters/security_practices.clj"]
            ;;; ... other options etc ... }
```

These files are loaded with `io/reader` like the existing `:config-files` option. Paths are relative to the project root directory.

And that's it!

## Technical details

`eastwood.util/add-linter` is an analogue to `eastwood.util/disable-warning`. The `:lint-files` are arbitrary Clojure files evaluated in the context of `eastwood.util`, similar to the existing `:config-files` option. Custom linter functions receive the same arguments as existing built-in lint functions.

In terms of the implementation, there's not much more to it - given the existing features of Eastwood, it was pretty clear how to add this :)

## Things to finalize

1. Need a new name for the `add-linter` API - I only just noticed it conflicts with the existing `:add-linter` configuration option for off-by-default linters built-in to Eastwood.
2. It would be good to have a story for third party libraries to distribute linters to their users. I *think* `io/reader` can load files from the resources of your dependencies, so in theory a project could just refer to those somehow. Imagine the Datomic client library containing Eastwood linters which provide linters that point out bad practices and inefficient ways of doing things.
3. If third party libraries can distribute linters, they should have globally unique linter names. It would be good for Eastwood to check for linter name uniqueness, and at least warn users when they've got a name conflict. Even better if they could be uniquefied automatically, but let's not get ahead of ourselves :)
4. Consider whether custom linters should be able to be turned off. Linters specific to a project probably don't need to be turned off by configuration (just comment out the call to `add-linter`), but if they're from some dependency of yours, you might want a bit more control.
5. Add more documentation to the README, and possibly elsewhere in the project. #182 specifically asked for documentation on how to do this, so even though I wrote the feature, I can't claim to have resolve that issue, haha. I know at least the "Last options map adjustments" section needs adjustment.