### PR TITLE
Update to Deps Versions dependency status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eastwood - a Clojure lint tool
 
-[![Dependencies Status](http://jarkeeper.com/jonase/eastwood/status.svg)](http://jarkeeper.com/jonase/eastwood)
+[![Dependencies Status](https://versions.deps.co/jonase/eastwood/status.svg)](https://versions.deps.co/jonase/eastwood)
 
 <img src="doc/Clint_Eastwood_-_1960s_small.jpg"
  alt="Picture of Clint Eastwood in 'A Fistful of Dollars' (1964)" title="Clint Eastwood in 'A Fistful of Dollars' (1964)"


### PR DESCRIPTION
I noticed in the logs for Deps Versions that there was an error thrown trying to load https://versions.deps.co/jonase/eastwood a few weeks ago. I think I've resolved that error now, so I'm providing a PR. If this wasn't a maintainer checking this, and you don't want to switch, feel free to close this.