### PR TITLE
Fix warnings on clojure macro expansions

### DIFF
--- a/resource/eastwood/config/clojure.clj
+++ b/resource/eastwood/config/clojure.clj
@@ -37,7 +37,8 @@
    :for-macro 'clojure.core/and
    :if-inside-macroexpansion-of #{'clojure.spec/every 'clojure.spec.alpha/every
                                   'clojure.spec/and 'clojure.spec.alpha/and
-                                  'clojure.spec/keys 'clojure.spec.alpha/keys}
+                                  'clojure.spec/keys 'clojure.spec.alpha/keys
+                                  'clojure.spec/coll-of 'clojure.spec.alpha/coll-of}
    :within-depth 6
    :reason "clojure.spec's macros `keys`, `every`, and `and` often contain `clojure.core/and` invocations with only one argument."})
 
@@ -46,3 +47,9 @@
   :if-inside-macroexpansion-of #{'clojure.core/cond-> 'clojure.core/cond->>}
   :within-depth 2
   :reason "Allow cond-> and cond->> to have constant tests without warning"})
+
+(disable-warning
+  {:linter :constant-test
+   :if-inside-macroexpansion-of #{'clojure.core/as->}
+   :within-depth 2
+   :reason "Allow as-> to have constant tests without warning"})


### PR DESCRIPTION
- `as->` was not handled like `cond->`
- `coll-of` was not handled like `keys` in spec

related to https://github.com/jonase/eastwood/issues/227