### PR TITLE
report-analyzer-exception calls eastwood.error-messages/format-exception with 2 args.

### DIFF
--- a/src/eastwood/error_messages.clj
+++ b/src/eastwood/error_messages.clj
@@ -228,7 +228,7 @@ curious." eastwood-url))
        {:info :show-more-details
         :msgs (print-ex-data-details ns-sym exc)}))))
 
-(defn format-exception [ns-sym opts ^Throwable exc]
+(defn format-exception [ns-sym ^Throwable exc]
   (let [dat (ex-data exc)
         msg (or (.getMessage exc) "")]
     (cond


### PR DESCRIPTION
The middle arg of eastwood.error-messages/format-exception is unused, so we remove it
to fix the bug.

Fixes #268