### PR TITLE
change version to the one available in clojars

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ released to fix that problem.
 Merge the following into your `$HOME/.lein/profiles.clj` file:
 
 ```clojure
-{:user {:plugins [[jonase/eastwood "0.2.7-SNAPSHOT"]] }}
+{:user {:plugins [[jonase/eastwood "0.2.7"]] }}
 ```
 
 To run Eastwood with the default set of lint warnings on all of the
@@ -424,7 +424,7 @@ If you use Leiningen, merge this into your project's `project.clj`
 file first:
 
 ```clojure
-:profiles {:dev {:dependencies [[jonase/eastwood "0.2.7-SNAPSHOT" :exclusions [org.clojure/clojure]]]}}
+:profiles {:dev {:dependencies [[jonase/eastwood "0.2.7" :exclusions [org.clojure/clojure]]]}}
 ```
 
 If you use a different build tool, you will need to add the dependency
@@ -659,7 +659,7 @@ can be used to modify this merging behavior.
 For example, if your user-wide `profiles.clj` file contains this:
 
 ```clojure
-{:user {:plugins [[jonase/eastwood "0.2.7-SNAPSHOT"]]
+{:user {:plugins [[jonase/eastwood "0.2.7"]]
         :eastwood {:exclude-linters [:unlimited-use]
                    :debug [:time]}
         }}
@@ -2296,7 +2296,7 @@ your local Maven repository:
     $ cd path/to/eastwood
     $ lein install
 
-Then add `[jonase/eastwood "0.2.7-SNAPSHOT"]` (or whatever is the
+Then add `[jonase/eastwood "0.2.7"]` (or whatever is the
 current version number in the defproject line of `project.clj`) to
 your `:plugins` vector in your `:user` profile, perhaps in your
 `$HOME/.lein/profiles.clj` file.


### PR DESCRIPTION
`0.2.7-SNAPSHOT` (as stated in the readme) is not available in clojars (please see https://github.com/jonase/eastwood/issues/271). This results in an error, as lein is not able to download specific version.