### PR TITLE
disable warning for eduction arguments

### DIFF
--- a/resource/eastwood/config/clojure.clj
+++ b/resource/eastwood/config/clojure.clj
@@ -53,3 +53,10 @@
    :if-inside-macroexpansion-of #{'clojure.core/as->}
    :within-depth 2
    :reason "Allow as-> to have constant tests without warning"})
+
+(disable-warning
+  {:linter :wrong-arity
+   :function-symbol 'clojure.core/eduction
+   :arglists-for-linting '([& xform])
+   :reason "eduction takes a sequence of transducer with a collection as the last item"})
+


### PR DESCRIPTION
The arglist in clojure specify `[xform* coll]`, so eastwood takes this as 2 arguments but it is really a list of 0 or more transducers and a collection at the end.

AFAIK, there no better way to express this in clojure so I am just defaulting to the real arguments defined in clojure source code `[& xforms]`

You can check that this fixed my project lint errors in my travis [history](https://travis-ci.org/hiposfer/kamal)

Hope it helps