### PR TITLE
Report analyzer exceptions when linting.

### DIFF
--- a/cases/testcases/analyzererror.clj
+++ b/cases/testcases/analyzererror.clj
@@ -1,0 +1,4 @@
+(ns testcases.analyzererror)
+
+;;This will cause an exception to be thrown when this file is analyzed.
+no.such.java.class

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -427,7 +427,7 @@ exception."))
       (->> lint-results
            (mapcat :lint-warning)
            (map :warn-data))
-      (throw exception))))
+      (throw (:exception exception)))))
 
 (defn unknown-ns-keywords [namespaces known-ns-keywords desc]
   (let [keyword-set (set (filter keyword? namespaces))
@@ -847,7 +847,9 @@ Return value:
                            (doseq [error lint-error]
                              (error-cb (:warn-data error)))
                            (doseq [warning lint-warning]
-                             (cb (assoc warning :opt opts)))))
+                             (cb (assoc warning :opt opts))))
+                         (when exception
+                           (error-cb (str/join "\n" (:msgs exception)))))
                        (catch RuntimeException e
                            (error-cb "Linting failed:")
                            (util/pst e nil error-cb)


### PR DESCRIPTION
Add a test case that will always throw an analysis error.

Before this commit, eastwood would swallow analyzer exceptions:

```
$ lein eastwood "{:namespaces [testcases.analyzererror]}"
== Eastwood 0.3.0-SNAPSHOT Clojure 1.8.0 JVM 1.8.0_144
== Linting testcases.analyzererror ==
== Warnings: 0 (not including reflection warnings)  Exceptions thrown: 0
```

After this commit, it reports them:

```
$ lein eastwood "{:namespaces [testcases.analyzererror]}"
== Eastwood 0.3.0-SNAPSHOT Clojure 1.8.0 JVM 1.8.0_144
== Linting testcases.analyzererror ==
Exception thrown during phase :analyze+eval of linting namespace testcases.analyzererror
Got exception with extra ex-data:
    msg='Class not found: no.such.java.class'
    (keys dat)=(:class :file :end-column :column :line :end-line)
ExceptionInfo Class not found: no.such.java.class
        clojure.core/ex-info (core.clj:4617)
        clojure.core/ex-info (core.clj:4617)
        eastwood.copieddeps.dep2.clojure.tools.analyzer.passes.jvm.validate/eval2055/fn--2057 (validate.clj:32)
        clojure.lang.MultiFn.invoke (MultiFn.java:229)
...

The following form was being processed during the exception:
no.such.java.class

Shown again with metadata for debugging (some metadata elided for brevity):
^{:line 4} no.such.java.class

An exception was thrown while analyzing namespace testcases.analyzererror
Lint results may be incomplete.  If there are compilation errors in
your code, try fixing those.  If not, check above for info on the
exception.
== Warnings: 0 (not including reflection warnings)  Exceptions thrown: 0
```

It looks like this was a bug introduced during a refactor (https://github.com/jonase/eastwood/pull/262), but it's difficult to tell.

It wasn't clear to me how to setup a test case for this behavior, so I omitted that in favor of running eastwood directly.