### PR TITLE
Add data to unused namespace linter.

### DIFF
--- a/src/eastwood/linters/unused.clj
+++ b/src/eastwood/linters/unused.clj
@@ -306,6 +306,7 @@ Example: (all-suffixes [1 2 3])
                                  (map namespace-for used-protocols)))]
     (for [ns (set/difference required used-namespaces)]
       {:loc loc
+       :unused-namespace-sym ns
        :linter :unused-namespaces
        :msg (format "Namespace %s is never used in %s" ns curr-ns)})))
 


### PR DESCRIPTION
Not sure if this is in scope for Eastwood or not, but I found this helpful on an internal fork.

If linters return data, they can be used programmatically.
In my case, I used this additional data to collect all unused namespaces and automatically rewrite the namespace form to not include those unnecessary namespaces.