### PR TITLE
Implicit dependency linter should ignore vars within macros defined in other namespaces.

### DIFF
--- a/test/eastwood/test/implicit_dependencies_linter_test.clj
+++ b/test/eastwood/test/implicit_dependencies_linter_test.clj
@@ -1,19 +1,17 @@
 (ns eastwood.test.implicit-dependencies-linter-test
-  (:use [clojure.test])
-  (:require [eastwood.test.linters-test :as linters-test]
-            [clojure.data :as data]
-            [clojure.pprint :as pp])
-  (:import (java.io File)))
+  (:require [clojure.test :refer :all]
+            [eastwood.test.linters-test :as linters-test]))
 
 
-(linters-test/lint-test
- 'testcases.implicit_dependencies
- [:implicit-dependencies]
- {}
- {{:linter :implicit-dependencies,
-   :msg
-   "Var clojure.string/join refers to namespace clojure.string that isn't explicitly required.",
-   :file "testcases/implicit_dependencies.clj",
-   :line 4,
-   :column 3}
-  1})
+(deftest implicit-dependency-linter
+  (linters-test/lint-test
+   'testcases.implicit_dependencies
+   [:implicit-dependencies]
+   {}
+   {{:linter :implicit-dependencies,
+     :msg
+     "Var clojure.string/join refers to namespace clojure.string that isn't explicitly required.",
+     :file "testcases/implicit_dependencies.clj",
+     :line 4,
+     :column 3}
+    1}))


### PR DESCRIPTION
Ref: https://github.com/jonase/eastwood/issues/288

I ran the linter against carmine as suggested by @jafingerhut and there are no warnings from the implicit-dependency linter after these changes.

I didn't update the changelog since 0.3.2 hasn't been released yet.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [ ] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)

Thanks!
