### PR TITLE
Suppress ":constant-test" warning for "or" inside clojure.spec's "coll-of"

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -3,6 +3,8 @@
 ## Changes from 0.3.1 to 0.3.2
 
 * Add `:implicit-dependencies` linter
+* Fix `:constant-test` warning on macro expansion of `clojure.spec`'s
+  `coll-of`
 
 ## Changes from version 0.2.x to 0.3.0
 

--- a/resource/eastwood/config/clojure.clj
+++ b/resource/eastwood/config/clojure.clj
@@ -44,6 +44,13 @@
 
 (disable-warning
  {:linter :constant-test
+  :for-macro 'clojure.core/or
+  :if-inside-macroexpansion-of #{'clojure.spec/coll-of 'clojure.spec.alpha/coll-of}
+  :within-depth 7
+  :reason "clojure.spec's `coll-of` can contain `clojure.core/or` invocations with only one argument."})
+
+(disable-warning
+ {:linter :constant-test
   :if-inside-macroexpansion-of #{'clojure.core/cond-> 'clojure.core/cond->>}
   :within-depth 2
   :reason "Allow cond-> and cond->> to have constant tests without warning"})


### PR DESCRIPTION
I ran into a nearly identical situation as @valerauko in [#273](https://github.com/jonase/eastwood/issues/273) (minus the `defstate` issue). This was the most narrowly targeted suppression that I was able to come up with and I confirmed this worked on my codebase using a custom config file.