### PR TITLE
Disable defonce warning for mount.core/defstate

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,8 @@
 # Change log for Eastwood
 
+## Changes from 0.3.2 to 0.3.3
+* Disable `:redefd-vars` warning for mount's `defstate`
+
 ## Changes from 0.3.1 to 0.3.2
 
 * Add `:implicit-dependencies` linter

--- a/resource/eastwood/config/clojure.clj
+++ b/resource/eastwood/config/clojure.clj
@@ -4,7 +4,9 @@
 
 (disable-warning
  {:linter :redefd-vars
-  :if-inside-macroexpansion-of #{'clojure.core/defonce 'clojure.core/defmulti}
+  :if-inside-macroexpansion-of #{'clojure.core/defonce
+                                 'clojure.core/defmulti
+                                 'mount.core/defstate}
   :within-depth 2
   :reason "defonce, defmulti expand to code with multiple def's for the same Var."})
 
@@ -66,4 +68,3 @@
    :function-symbol 'clojure.core/eduction
    :arglists-for-linting '([& xform])
    :reason "eduction takes a sequence of transducer with a collection as the last item"})
-


### PR DESCRIPTION
As described in #273, mount's defstate is reported with a multiple-def warning.

defstate uses defonce internally, but for some reason it isn't recognized as its expansion (even with very large depth).

The simplest solution is to add defstate to the list of the def* exception.