### PR TITLE
Remove callbacks + cleanups

### DIFF
--- a/src/eastwood/analyze_ns.clj
+++ b/src/eastwood/analyze_ns.clj
@@ -71,29 +71,28 @@ the value of File/separator for the platform."
 (defn pre-analyze-debug [asts form _env ns opt]
   (when (util/debug? :ns opt)
     (let [print-normally? (util/debug? :forms opt)
-          pprint? (util/debug? :forms-pprint opt)
-          debug-cb (util/make-msg-cb :debug opt)]
+          pprint? (util/debug? :forms-pprint opt)]
       (when (or print-normally? pprint?)
-        (debug-cb (format "dbg pre-analyze #%d ns=%s (meta ns)=%s"
+        (println (format "dbg pre-analyze #%d ns=%s (meta ns)=%s"
                           (count asts) (str ns) (meta ns)))
         (when pprint?
-          (debug-cb "    form before macroexpand:")
-          (debug-cb (with-out-str (pp/pprint form))))
+          (println "    form before macroexpand:")
+          (pp/pprint form))
         (when print-normally?
-          (debug-cb "    form before macroexpand, with metadata (some elided for brevity):")
-          (debug-cb (with-out-str (util/pprint-meta-elided form))))
-        (debug-cb "\n    --------------------")
+          (println "    form before macroexpand, with metadata (some elided for brevity):")
+          (util/pprint-meta-elided form))
+        (println "\n    --------------------")
         (if (dont-expand-twice? form)
           (when print-normally?
-            (debug-cb "    form is gen-interface, so avoiding macroexpand on it"))
+            (println "    form is gen-interface, so avoiding macroexpand on it"))
           (let [exp (macroexpand form)]
             (when pprint?
-              (debug-cb "    form after macroexpand:")
-              (debug-cb (with-out-str (pp/pprint exp))))
+              (println "    form after macroexpand:")
+              (pp/pprint exp))
             (when print-normally?
-              (debug-cb "    form after macroexpand, with metadata (some elided for brevity):")
-              (debug-cb (with-out-str (util/pprint-meta-elided exp))))))
-        (debug-cb "\n    --------------------")))))
+              (println "    form after macroexpand, with metadata (some elided for brevity):")
+              (util/pprint-meta-elided exp))))
+        (println "\n    --------------------")))))
 
 (def ^:dynamic *forms-read-writer* nil)
 (def ^:dynamic *forms-analyzed-writer* nil)
@@ -124,11 +123,9 @@ the value of File/separator for the platform."
 
 (defn post-analyze-debug [filename asts form ast ns opt]
   (when (util/debug? :ns opt)
-    (let [show-ast? (util/debug? :ast opt)
-          cb (:callback opt)
-          debug-cb (util/make-msg-cb :debug opt)]
+    (let [show-ast? (util/debug? :ast opt)]
       (when (or show-ast? (util/debug? :progress opt))
-        (debug-cb (format "dbg anal'd %d ns=%s%s"
+        (println(format "dbg anal'd %d ns=%s%s"
                           (count asts) (str ns)
                           (if show-ast? " ast=" ""))))
       (when show-ast?
@@ -145,10 +142,9 @@ the value of File/separator for the platform."
 
 (defn before-analyze-file-debug [source-path opt]
   (when (util/debug? :ns opt)
-    (let [debug-cb (util/make-msg-cb :debug opt)]
-      (debug-cb (format "all-ns before (analyze-file \"%s\") begins:"
-                        source-path))
-      (debug-cb (with-out-str (pp/pprint (sort (all-ns-names-set))))))))
+    (println (format "all-ns before (analyze-file \"%s\") begins:"
+                     source-path))
+    (pp/pprint (sort (all-ns-names-set)))))
 
 (defn eastwood-wrong-tag-handler [t ast]
   (let [tag (if (= t :name/tag)

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -11,26 +11,15 @@
             [eastwood.copieddeps.dep9.clojure.tools.namespace.track :as track]
             [eastwood.error-messages :as msgs]
             [eastwood.linters.deprecated :as deprecated]
+            [eastwood.linters.implicit-dependencies :as implicit-dependencies]
             [eastwood.linters.misc :as misc]
             [eastwood.linters.typetags :as typetags]
             [eastwood.linters.typos :as typos]
             [eastwood.linters.unused :as unused]
-            [eastwood.linters.implicit-dependencies :as implicit-dependencies]
             [eastwood.reporting-callbacks :as reporting]
             [eastwood.util :as util]
             [eastwood.version :as version])
   (:import java.io.File))
-
-(def ^:dynamic *eastwood-version*
-  {:major version/major, :minor version/minor, :incremental version/patch, :qualifier version/pre-release})
-
-(defn eastwood-version [] version/string)
-
-(defmulti error-msg
-  "Given a map describing an Eastwood error result, which should
-always have at least the keys :err and :err-data, return a string
-describing the error."
-  :err)
 
 ;; Note: Linters below with nil for the value of the key :fn,
 ;; e.g. :no-ns-form-found, can be enabled/disabled from the opt map
@@ -142,14 +131,6 @@ describing the error."
      {:namespace-sym ns-sym}
      (util/file-warn-info uri cwd-file))))
 
-(defn make-lint-warning [kw msg opts file]
-  {:kind :lint-warning,
-   :warn-data (let [inf (util/file-warn-info file (:cwd opts))]
-                (merge
-                 {:linter kw
-                  :msg (format (str msg " '%s'.  It will not be linted.")
-                               (:uri-or-file-name inf))}
-                 inf))})
 
 (defn- handle-lint-result [linter ns-info {:keys [msg loc] :as result}]
   {:kind :lint-warning,
@@ -169,34 +150,6 @@ describing the error."
           :warn-data (format "Exception thrown by linter %s on namespace %s" (:name linter) ns-sym)
           :exception e}]))))
 
-(defn report-warnings [cb warning-count warnings]
-  (swap! warning-count + (count warnings))
-  (doseq [warning warnings]
-    (cb warning)))
-
-(defn- report-analyzer-exception [exception exception-phase exception-form ns-sym]
-  (let [[strings error-cb] (msgs/string-builder)]
-    (error-cb (str "Exception thrown during phase " exception-phase
-                   " of linting namespace " ns-sym))
-    (let [{:keys [msgs info]} (msgs/format-exception ns-sym exception)]
-      (swap! strings into msgs)
-      (when (= info :show-more-details)
-        (error-cb "\nThe following form was being processed during the exception:")
-        ;; TBD: Replace this binding with util/pprint-form variation
-        ;; that does not print metadata?
-        (error-cb (with-out-str (binding [*print-level* 7
-                                          *print-length* 50]
-                                  (pp/pprint exception-form))))
-        (error-cb "\nShown again with metadata for debugging (some metadata elided for brevity):")
-        (error-cb (with-out-str (util/pprint-form exception-form)))))
-    (error-cb
-     (str "\nAn exception was thrown while analyzing namespace " ns-sym "
-Lint results may be incomplete.  If there are compilation errors in
-your code, try fixing those.  If not, check above for info on the
-exception."))
-    {:exception exception
-     :msgs @strings}))
-
 (defn lint-ns* [ns-sym analyze-results opts linter]
   (let [[results elapsed] (util/timeit (run-linter linter analyze-results ns-sym opts))]
     (->> results
@@ -212,32 +165,18 @@ exception."))
      :lint-results (some->> linters
                             (keep linter-name->info)
                             (map (partial lint-ns* ns-sym analyze-results opts)))
-     :exception (when exception
-                  (report-analyzer-exception exception exception-phase exception-form ns-sym))}))
-
-(declare last-options-map-adjustments)
-
+     :analyzer-exception (when exception
+                           (msgs/report-analyzer-exception exception exception-phase exception-form ns-sym))}))
 
 (defn unknown-ns-keywords [namespaces known-ns-keywords desc]
   (let [keyword-set (set (filter keyword? namespaces))
         unknown-ns-keywords (set/difference keyword-set known-ns-keywords)]
-    (if (empty? unknown-ns-keywords)
-      nil
-      {:err :unknown-ns-keywords,
-       :err-data {:for-option desc
-                  :unknown-ns-keywords unknown-ns-keywords
-                  :allowed-ns-keywords known-ns-keywords}})))
-
-(defmethod error-msg :unknown-ns-keywords [err-info]
-  (let [{:keys [for-option unknown-ns-keywords allowed-ns-keywords]}
-        (:err-data err-info)]
-    (with-out-str
-      (println (format "The following keywords appeared in the namespaces specified after %s :"
-                       for-option))
-      (println (format "    %s" (seq unknown-ns-keywords)))
-      (println (format "The only keywords allowed in this list of namespaces are: %s"
-                       (seq allowed-ns-keywords))))))
-
+    (when-not (empty? unknown-ns-keywords)
+      (throw (ex-info "unknown-ns-keywords"
+                      {:err :unknown-ns-keywords,
+                       :err-data {:for-option desc
+                                  :unknown-ns-keywords unknown-ns-keywords
+                                  :allowed-ns-keywords known-ns-keywords}})))))
 
 (defn filename-to-ns [fname]
   (-> fname
@@ -279,123 +218,41 @@ exception."))
                :recommended-fnames desired-fname-set,
                :recommended-namespace desired-ns}]))))
 
-(defn canonical-filename
-  "Returns the canonical file name for the given file name.  A
-canonical file name is platform dependent, but is both absolute and
-unique.  See the Java docs for getCanonicalPath for some more details,
-and the examples below.
-
-    http://docs.oracle.com/javase/7/docs/api/java/io/File.html#getCanonicalPath%28%29
-
-Examples:
-
-Context: A Linux or Mac OS X system, where the current working
-directory is /Users/jafinger/clj/dolly
-
-user=> (canonical-filename \"README.md\")
-\"/Users/jafinger/clj/dolly/README.md\"
-
-user=> (canonical-filename \"../../Documents/\")
-\"/Users/jafinger/Documents\"
-
-user=> (canonical-filename \"../.././clj/../Documents/././\")
-\"/Users/jafinger/Documents\"
-
-Context: A Windows 7 system, where the current working directory is
-C:\\Users\\jafinger\\clj\\dolly
-
-user=> (canonical-filename \"README.md\")
-\"C:\\Users\\jafinger\\clj\\dolly\\README.md\"
-
-user=> (canonical-filename \"..\\..\\Documents\\\")
-\"C:\\Users\\jafinger\\Documents\"
-
-user=> (canonical-filename \"..\\..\\.\\clj\\..\\Documents\\.\\.\\\")
-\"C:\\Users\\jafinger\\Documents\""
-  [fname]
-  (let [^java.io.File f (if (instance? java.io.File fname)
-                          fname
-                          (java.io.File. ^String fname))]
-    (.getCanonicalPath f)))
-
-(defn nss-in-dirs [dir-name-strs opt warning-count]
-  (let [dir-name-strs (map canonical-filename dir-name-strs)
+(defn nss-in-dirs [dir-name-strs]
+  (let [dir-name-strs (set (map util/canonical-filename dir-name-strs))
         mismatches (filename-namespace-mismatches dir-name-strs)]
-    (if (seq mismatches)
-      {:err :namespace-filename-mismatch
-       :err-data {:mismatches mismatches}}
-      (let [tracker (if (seq dir-name-strs)
-                      (dir/scan-dirs (track/tracker) dir-name-strs)
-                      ;; Use empty tracker if dir-name-strs is empty.
-                      ;; Calling dir/scan-all will use complete Java
-                      ;; classpath if called with an empty sequence.
-                      (track/tracker))
-            files-no-ns-form-found
-            (when (some #{:no-ns-form-found} (:enabled-linters opt))
-              (let [tfiles (-> tracker
-                               :eastwood.copieddeps.dep9.clojure.tools.namespace.dir/files
-                               set)
-                    tfilemap (-> tracker
-                                 :eastwood.copieddeps.dep9.clojure.tools.namespace.file/filemap
-                                 keys
-                                 set)
-                    maybe-data-readers (->> dir-name-strs
-                                            (map #(File.
-                                                   (str % File/separator
-                                                        "data_readers.clj")))
-                                            set)]
-                (set/difference tfiles tfilemap maybe-data-readers)))]
-        {:err nil
-         :dirs (map #(util/file-warn-info % (:cwd opt)) dir-name-strs)
-         :non-clojure-files
-         (:eastwood.copieddeps.dep9.clojure.tools.namespace.dir/non-clojure-files
-          tracker)
-         :no-ns-form-found-files files-no-ns-form-found
-         :namespaces
-         (:eastwood.copieddeps.dep9.clojure.tools.namespace.track/load
-          tracker)}))))
+    (when (seq mismatches)
+      (throw (ex-info "namespace-file-name-mismatch"
+                      {:err :namespace-filename-mismatch
+                       :err-data {:mismatches mismatches}})))
+    (let [tracker (if (seq dir-name-strs)
+                    (dir/scan-dirs (track/tracker) dir-name-strs)
+                    ;; Use empty tracker if dir-name-strs is empty.
+                    ;; Calling dir/scan-all will use complete Java
+                    ;; classpath if called with an empty sequence.
+                    (track/tracker))]
+      {:dirs dir-name-strs
+       :non-clojure-files (::dir/non-clojure-files tracker)
+       :files (set (::dir/files tracker))
+       :file-map (::file/filemap tracker)
+       :namespaces (::track/load tracker)})))
 
+(defn expand-ns-keywords
+  "Expand any keyword in `namespaces` with values from `expanded-namespaces`"
+  [expanded-namespaces namespaces]
+  (mapcat (fn [x] (get expanded-namespaces x [x])) namespaces))
 
-(defmethod error-msg :namespace-filename-mismatch [err-info]
-  (let [{:keys [mismatches]} (:err-data err-info)]
-    (with-out-str
-      (println "The following file(s) contain ns forms with namespaces that do not correspond
-with their file names:")
-      (doseq [[fname {:keys [dir namespace recommended-fnames recommended-namespace]}]
-              mismatches]
-        (println (format "Directory: %s" dir))
-        (println (format "    File                   : %s" fname))
-        (println (format "    has namespace          : %s" namespace))
-        (if (= namespace recommended-namespace)
-          ;; Give somewhat clearer message in this case
-          (println (format "    should be in file(s)   : %s"
-                           (str/join "\n                             "
-                                     recommended-fnames)))
-          (do
-            (println (format "    should have namespace  : %s"
-                             recommended-namespace))
-            (println (format "    or should be in file(s): %s"
-                             (str/join "\n                             "
-                                       recommended-fnames))))))
-      (println "
-No other linting checks will be performed until these problems have
-been corrected.
-
-The 'should have namespace' and 'should be in file' messages above are
-merely suggestions.  It may be better in your case to rename both the
-file and namespace to avoid name collisions."))))
-
-
-(defn replace-ns-keywords [namespaces source-paths test-paths]
-  (mapcat (fn [x]
-            (if (keyword? x)
-              (case x
-                :source-paths source-paths
-                :test-paths test-paths
-                ;;:force-order []
-                )
-              [x]))
-          namespaces))
+(defn setup-lint-paths
+  "Return a map containing `:source-path` and `:test-paths` which
+  contains the set of values in each. If both `source-paths` and `test-paths`
+  are empty then `:source-path` is set to all the directories on the classpath,
+  while `:test-paths` is the empty set."
+  [source-paths test-paths]
+  (if-not (or (seq source-paths) (seq test-paths))
+    {:source-paths (set (classpath/classpath-directories))
+     :test-paths #{}}
+    {:source-paths (set source-paths)
+     :test-paths (set test-paths)}))
 
 ;; If you do not specify :namespaces in the options, it defaults to
 ;; the same as if you specified [:source-paths :test-paths].  If you
@@ -415,55 +272,33 @@ file and namespace to avoid name collisions."))))
 ;; TBD: Abort with an easily understood error message if a namespace
 ;; is given that cannot be found.
 
-(defn opts->namespaces [opts warning-count]
-  (let [namespaces1 (distinct (:namespaces opts))
-        sp-included? (some #{:source-paths} namespaces1)
-        tp-included? (some #{:test-paths} namespaces1)
-        excluded-namespaces (set (:exclude-namespaces opts))]
-    ;; Return an error if any keywords appear in the namespace lists
-    ;; that are not recognized.
-    (or
-     (unknown-ns-keywords namespaces1 #{:source-paths :test-paths}
-                          ":namespaces")
-     (unknown-ns-keywords excluded-namespaces #{:source-paths :test-paths}
-                          ":exclude-namespaces")
-     ;; If keyword :source-paths occurs in namespaces1 or
-     ;; excluded-namespaces, replace it with all namespaces found in
-     ;; the directories in (:source-paths opts), in an order that
-     ;; honors dependencies, and similarly for :test-paths.
-     ;; nss-in-dirs traverses part of the file system, so only call it
-     ;; once for each of :source-paths and :test-paths, and only if
-     ;; needed.
-     (let [all-ns (concat namespaces1 excluded-namespaces)
-           sp (if (some #{:source-paths} all-ns)
-                (nss-in-dirs (:source-paths opts) opts warning-count))
-           tp (if (some #{:test-paths} all-ns)
-                (nss-in-dirs (:test-paths opts) opts warning-count))]
-       (cond
-        (:err sp) sp
-        (:err tp) tp
-        :else
-        (let [source-paths (:namespaces sp)
-              test-paths (:namespaces tp)
-              namespaces (replace-ns-keywords namespaces1
-                                              source-paths test-paths)
-              namespaces (distinct namespaces)
-              excluded-namespaces (set (replace-ns-keywords excluded-namespaces
-                                                            source-paths
-                                                            test-paths))
-              namespaces (remove excluded-namespaces namespaces)]
-          {:err nil,
-           :namespaces namespaces,
-           :dirs (distinct (concat (if sp-included? (:dirs sp))
-                                   (if tp-included? (:dirs tp))))
-           :no-ns-form-found-files
-           (concat
-            (if sp-included? (:no-ns-form-found-files sp))
-            (if tp-included? (:no-ns-form-found-files tp)))
-           :non-clojure-files (concat
-                               (if sp-included? (:non-clojure-files sp))
-                               (if tp-included? (:non-clojure-files tp)))}))))))
-
+(defn effective-namespaces [exclude-namespaces namespaces
+                          {:keys [source-paths test-paths]}]
+  ;; If keyword :source-paths occurs in namespaces or
+  ;; excluded-namespaces, replace it with all namespaces found in
+  ;; the directories in (:source-paths opts), in an order that
+  ;; honors dependencies, and similarly for :test-paths.
+  ;; nss-in-dirs traverses part of the file system, so only call it
+  ;; once for each of :source-paths and :test-paths, and only if
+  ;; needed.
+  (let [all-ns (concat namespaces exclude-namespaces)
+        sp (if (some #{:source-paths} all-ns)
+             (nss-in-dirs source-paths))
+        tp (if (some #{:test-paths} all-ns)
+             (nss-in-dirs test-paths))
+        expanded-namespaces {:source-paths (:namespaces sp)
+                             :test-paths (:namespaces tp)}
+        excluded-namespaces (set (expand-ns-keywords expanded-namespaces
+                                                     exclude-namespaces))]
+    {:namespaces (->> namespaces
+                      (expand-ns-keywords expanded-namespaces)
+                      distinct
+                      (remove excluded-namespaces))
+     :dirs (concat (:dirs sp) (:dirs tp))
+     :files (set (concat (:files sp) (:files tp)))
+     :file-map (merge (:file-map sp) (:file-map tp))
+     :non-clojure-files (set/union (:non-clojure-files sp)
+                                   (:non-clojure-files tp))}))
 
 (defn replace-linter-keywords [linters all-linters default-linters]
   (mapcat (fn [x]
@@ -472,92 +307,60 @@ file and namespace to avoid name collisions."))))
                   :else [x]))
           linters))
 
-
 (defn linter-seq->set [linter-seq]
   (set (replace-linter-keywords linter-seq all-linters default-linters)))
 
-
-(defn opts->linters [opts linter-name->info default-linters]
-  (let [linters-orig (linter-seq->set (:linters opts))
-        excluded-linters (linter-seq->set (:exclude-linters opts))
-        add-linters (linter-seq->set (:add-linters opts))
+(defn effective-linters
+  [{:keys [linters exclude-linters add-linters disable-linter-name-checks]}
+   linter-name->info default-linters]
+  (let [linters-orig (linter-seq->set linters)
+        excluded-linters (linter-seq->set exclude-linters)
+        add-linters (linter-seq->set add-linters)
         linters-requested (-> (set/difference linters-orig excluded-linters)
                               (set/union add-linters))
         known-linters (set (keys linter-name->info))
         unknown-linters (set/difference (set/union linters-requested
                                                    excluded-linters)
-                                        known-linters)
-        linters (set/intersection linters-requested known-linters)]
-    (when (util/debug? :options opts)
-      (let [debug-cb (util/make-msg-cb :debug opts)]
-        (debug-cb "Calculation of final list of linters:")
-        (debug-cb (format "    :linters"))
-        (debug-cb (format "      before keyword substitution: %s" (vec (:linters opts))))
-        (debug-cb (format "      after  keyword substitution: %s" (vec (sort linters-orig))))
-        (debug-cb (format "    :exclude-linters"))
-        (debug-cb (format "      before keyword substitution: %s" (vec (:exclude-linters opts))))
-        (debug-cb (format "      after  keyword substitution: %s" (vec (sort excluded-linters))))
-        (debug-cb (format "    :add-linters"))
-        (debug-cb (format "      before keyword substitution: %s" (vec (:add-linters opts))))
-        (debug-cb (format "      after  keyword substitution: %s" (vec (sort add-linters))))
-        (debug-cb (format "    final effective linter set: linters - exclude + add:"))
-        (debug-cb (format "      %s" (vec (sort linters))))))
-    (if (and (seq unknown-linters)
-             (not (:disable-linter-name-checks opts)))
-      {:err :unknown-linter,
-       :err-data {:unknown-linters unknown-linters
-                  :known-linters known-linters}}
-      ;; else
-      {:err nil, :linters linters})))
+                                        known-linters)]
+    (when (and (seq unknown-linters)
+             (not disable-linter-name-checks))
+      (throw (ex-info "unknown-linter"
+              {:err :unknown-linter,
+               :err-data {:unknown-linters unknown-linters
+                          :known-linters known-linters}})))
 
+    (set/intersection linters-requested known-linters)))
 
-(defmethod error-msg :unknown-linter [err-info]
-  (let [{:keys [unknown-linters known-linters]} (:err-data err-info)]
-    (with-out-str
-      (println (format "The following requested or excluded linters are unknown: %s"
-                       (seq unknown-linters)))
-      (println (format "Known linters are: %s"
-                       (seq (sort known-linters)))))))
-
-
-(defmethod error-msg :exception-thrown [err-info]
-  (let [{:keys [unanalyzed-namespaces last-namespace]} (:err-data err-info)]
-    ;; Don't report that we stopped analyzing early if we stop on the
-    ;; last namespace (it is especially bad form to print the long
-    ;; message if only one namespace was being linted).
-    (if (seq unanalyzed-namespaces)
-      (format "
-Stopped analyzing namespaces after %s
-due to exception thrown.  %d namespaces left unanalyzed.
-
-If you wish to force continuation of linting after an exception in one
-namespace, make the option map key :continue-on-exception have the
-value true.
-
-WARNING: This can cause exceptions to be thrown while analyzing later
-namespaces that would not otherwise occur.  For example, if a function
-is defined in the namespace where the first exception occurs, after
-the exception, it will never be evaluated.  If the function is then
-used in namespaces analyzed later, it will be undefined, causing
-error.
-"
-            last-namespace
-            (count unanalyzed-namespaces))
-
-      "
-Exception thrown while analyzing last namespace.
-"
-      )))
-
-(defn- dirs-scanned [dirs]
+(defn- dirs-scanned [reporter cwd dirs]
   (when dirs
-    (println "Directories scanned for source files:")
-    (print " ")
+    (reporting/note reporter "Directories scanned for source files:")
+    (reporting/note reporter " ")
     (->> dirs
+         (map #(util/file-warn-info % cwd))
          (map :uri-or-file-name)
          (str/join " ")
-         (println))
-    (flush)))
+         (reporting/note reporter))))
+
+
+(defn- lint-namespace [reporter namespace linters opts]
+  (try
+    (let [{:keys [analyzer-exception lint-results analysis-time]} (lint-ns namespace linters opts)]
+      {:namespace [namespace]
+       :lint-warnings (mapcat :lint-warning lint-results)
+       :lint-errors (mapcat :lint-error lint-results)
+       :lint-times [(into {} (map (juxt (comp :name :linter) :elapsed) lint-results))]
+       :analysis-time [analysis-time]
+       :analyzer-exception (when analyzer-exception
+                             [analyzer-exception])})
+    (catch RuntimeException e
+      {:lint-runtime-exception [e]
+       :namespace [namespace]})))
+
+
+(defn debug-namespaces-to-be-reported [reporter namespaces]
+  (reporting/debug reporter :ns (format "Namespaces to be linted:"))
+  (doseq [n namespaces]
+    (reporting/debug reporter :ns (format "    %s" n))))
 
 (defn eastwood-core
   "Lint a sequence of namespaces using a specified collection of linters.
@@ -585,170 +388,121 @@ Side effects:
 Return value:
 + TBD
 "
-  [opts]
-  (let [warning-count (atom 0)
-        exception-count (atom 0)
-        cb (:callback opts)
-        {:keys [linters] :as m1} (opts->linters opts linter-name->info
-                                                default-linters)
-        opts (assoc opts :enabled-linters linters)
-        {:keys [namespaces dirs no-ns-form-found-files
-                non-clojure-files] :as m2}
-        (opts->namespaces opts warning-count)]
-    (dirs-scanned dirs)
-    (when (some #{:no-ns-form-found} (:enabled-linters opts))
-      (->> no-ns-form-found-files
-           (map (partial make-lint-warning :no-ns-form-found "No ns form was found in file" opts))
-           (map (fn [m] (assoc m :opt opts)))
-           (report-warnings cb warning-count)))
-    (when (some #{:non-clojure-file} (:enabled-linters opts))
-      (->> non-clojure-files
-           (map (partial make-lint-warning :non-clojure-file "Non-Clojure file" opts))
-           (map (fn [m] (assoc m :opt opts)))
-           (report-warnings cb warning-count)))
-    (cond
-     (:err m1) m1
-     (:err m2) m2
-     :else
-     (let [error-cb (util/make-msg-cb :error opts)
-           debug-cb (util/make-msg-cb :debug opts)
-           note-cb (util/make-msg-cb :note opts)
-           continue-on-exception? (:continue-on-exception opts)
-           stopped-on-exc (atom false)
-           print-time? (util/debug? :time opts)]
-       (when (util/debug? :ns opts)
-         (debug-cb (format "Namespaces to be linted:"))
-         (doseq [n namespaces]
-           (debug-cb (format "    %s" n))))
-       ;; Create all namespaces to be analyzed.  This can help in some
-       ;; (unusual) situations, such as when namespace A requires B,
-       ;; so Eastwood analyzes B first, but eval'ing B assumes that
-       ;; A's namespace has been created first because B contains
-       ;; (alias 'x 'A)
-       (doseq [n namespaces]
-         (create-ns n))
-       (when (seq (:enabled-linters opts))
-         (loop [namespaces namespaces]
-           (when-first [namespace namespaces]
-             (let [e (try
-                       (note-cb (str "== Linting " namespace " =="))
-                       (let [{:keys [exception lint-results analysis-time]} (lint-ns namespace (:enabled-linters opts) opts)]
-                         (when print-time?
-                           (note-cb (format "Analysis took %.1f millisec" analysis-time)))
-                         (when exception
-                           (swap! exception-count inc))
-                         (doseq [{:keys [lint-warning lint-error elapsed linter]} lint-results]
-                           (when print-time?
-                             (note-cb (format "Linter %s took %.1f millisec"
-                                              (:name linter) elapsed)))
-                           (swap! warning-count + (count lint-warning))
-                           (swap! exception-count + (count lint-error))
-                           (doseq [error lint-error]
-                             (error-cb (:warn-data error))
-                             (when (contains? error :exception)
-                               (let [{:keys [msgs]}
-                                     (msgs/format-exception namespace
-                                                            (:exception error))]
-                                 (doseq [msg msgs] (error-cb msg)))))
-                           (doseq [warning lint-warning]
-                             (cb (assoc warning :opt opts))))
-                         (when exception
-                           (error-cb (str/join "\n" (:msgs exception)))))
-                       (catch RuntimeException e
-                           (error-cb "Linting failed:")
-                           (util/pst e nil error-cb)
-                           e))]
-               (if (or continue-on-exception?
-                       (not (instance? Throwable e)))
-                 (recur (next namespaces))
-                 (reset! stopped-on-exc
-                         {:exception e
-                          :last-namespace namespace
-                          :unanalyzed-namespaces (next namespaces)}))))))
-       (merge
-        {:err nil
-         :warning-count @warning-count
-         :exception-count @exception-count}
-        (if @stopped-on-exc
-          {:err :exception-thrown
-           :err-data @stopped-on-exc}))))))
-
-;; Test Eastwood for a while with messages being written to file
-;; "east-out.txt", to see if I catch everything that was going to
-;; *out* with callback functions or return values.
-
-;; Use the java.io.PrintWriter shown below to write messages to the
-;; same place as Eastwood does in version 0.1.4.
-
+  [reporter opts cwd {:keys [namespaces dirs files file-map
+                             non-clojure-files] :as info} linters]
+  (let [stop-on-exception? (not (:continue-on-exception opts))]
+    (dirs-scanned reporter cwd dirs)
+    (let [no-ns-forms (misc/no-ns-form-found-files dirs files file-map linters cwd)
+          non-clojure-files (misc/non-clojure-files non-clojure-files linters cwd)]
+      (reporting/report-result reporter no-ns-forms)
+      (reporting/report-result reporter non-clojure-files)
+      (when (seq linters)
+        (reporting/debug-namespaces reporter namespaces)
+        ;; Create all namespaces to be analyzed.  This can help in some
+        ;; (unusual) situations, such as when namespace A requires B,
+        ;; so Eastwood analyzes B first, but eval'ing B assumes that
+        ;; A's namespace has been created first because B contains
+        ;; (alias 'x 'A)
+        (doseq [n namespaces] (create-ns n))
+        (reduce (fn [results namespace]
+                  (reporting/note reporter (str "== Linting " namespace " =="))
+                  (let [result (lint-namespace reporter namespace linters opts)
+                        results (conj results result)]
+                    (if (and stop-on-exception?
+                             (or (:lint-runtime-exception result)
+                                 (:analyzer-exception result)))
+                      (do
+                        (reporting/stopped-on-exception reporter namespaces results result)
+                        (reduced results))
+                      (do
+                        (reporting/report-result reporter result)
+                        results))))
+                [no-ns-forms non-clojure-files]
+                namespaces)))))
 
 (def default-builtin-config-files
   ["clojure.clj"
    "clojure-contrib.clj"
    "third-party-libs.clj"])
 
+(def default-opts {:cwd (.getCanonicalFile (io/file "."))
+                   :linters default-linters
+                   :debug #{}
+                   :source-paths #{}
+                   :test-paths #{}
+                   :namespaces #{:source-paths :test-paths}
+                   :exclude-namespaces #{}
+                   :config-files #{}
+                   :builtin-config-files default-builtin-config-files})
 
-(defn last-options-map-adjustments [opts]
-  (let [opts (update-in opts [:debug] set)
-        opts (merge {:cwd (.getCanonicalFile (io/file "."))
-                     :linters default-linters
-                     :namespaces [:source-paths :test-paths]
-                     :builtin-config-files default-builtin-config-files}
-                    opts)
-        ;; special case 'merge': If _neither_ of :source-paths or
-        ;; :test-paths were specified in the options map, then set
-        ;; _one_ of them to a list of all the directories on the
-        ;; classpath.  If either is present, leave them both as is.
-        ;; Both of these should always have a value if invoked from
-        ;; Leiningen command line, so this is only for when invoked
-        ;; directly, e.g. from the REPL, intended as a convenience.
-        opts (if (or (contains? opts :source-paths)
-                     (contains? opts :test-paths))
-               opts
-               (assoc opts :source-paths
-                      (classpath/classpath-directories)))
-        ;; The following value is equivalent to (merge {:callback ...}
-        ;; opts), but it does not calculate the value unless needed.
-        opts (if (contains? opts :callback)
-               opts
-               (assoc opts :callback (reporting/make-default-cb opts)))
-
+(defn last-options-map-adjustments [opts reporter]
+  (let [opts (merge default-opts opts)
+        opts (-> opts
+                 (update :debug set)
+                 (update :namespaces set)
+                 (update :source-paths set)
+                 (update :test-paths set)
+                 (update :exclude-namespaces set))
         ;; Changes below override anything in the caller-provided
         ;; options map.
         opts (assoc opts :warning-enable-config
-                    (util/init-warning-enable-config opts))]
+                    (util/init-warning-enable-config
+                     (:builtin-config-files opts)
+                     (:config-files opts) opts))]
+    (reporting/debug reporter
+                     :options (with-out-str
+                                (println "\nOptions map after filling in defaults:")
+                                (pp/pprint (into (sorted-map) opts))))
+
+    ;; throw an error if any keywords appear in the namespace lists
+    ;; that are not recognized.
+    (unknown-ns-keywords (:namespaces opts) #{:source-paths :test-paths} ":namespaces")
+    (unknown-ns-keywords (:exclude-namespaces opts) #{:source-paths :test-paths} ":exclude-namespaces")
     opts))
 
+(defn summary [results]
+  (apply merge-with into results))
 
-(defn eastwood [opts]
-  ;; Use caller-provided :cwd and :callback values if provided
-  (let [opts (last-options-map-adjustments opts)
-        _ (when (util/debug? :options opts)
-            (println "\nOptions map after filling in defaults:")
-            (pp/pprint (into (sorted-map) opts)))
-        _ (when (util/debug? :var-info opts)
-            (util/print-var-info-summary @typos/var-info-map-delayed opts))
-        error-cb (util/make-msg-cb :error opts)
-        note-cb (util/make-msg-cb :note opts)
-        debug-cb (util/make-msg-cb :debug opts)
-        _ (do
-            (note-cb (format "== Eastwood %s Clojure %s JVM %s"
-                             (eastwood-version)
-                             (clojure-version)
-                             (get (System/getProperties) "java.version")))
-            (when (util/debug? :compare-forms opts)
-              (debug-cb "Writing files forms-read.txt and forms-emitted.txt")))
-        {:keys [err warning-count exception-count] :as ret}
-        (eastwood-core opts)]
-    (when err
-      (error-cb (error-msg ret)))
-    (when (number? warning-count)
-      (note-cb (format "== Warnings: %d (not including reflection warnings)  Exceptions thrown: %d"
-                       warning-count exception-count)))
-    (if (or err (and (number? warning-count)
-                     (or (> warning-count 0) (> exception-count 0))))
-      {:some-warnings true}
-      {:some-warnings false})))
+(defn counted-summary [summary]
+  {:warning-count (count (:lint-warnings summary))
+   :error-count (+ (count (:lint-errors summary))
+                   (count (:lint-runtime-exception summary))
+                   (count (:analyzer-exception summary)))
+   :lint-time (apply + (mapcat vals(:lint-times summary)))
+   :analysis-time (apply + (:analysis-time summary))})
 
+(defn make-report [reporter {:keys [warning-count error-count] :as result}]
+  (reporting/note reporter (format "== Warnings: %d (not including reflection warnings)  Exceptions thrown: %d"
+                                   warning-count
+                                   error-count))
+  {:some-warnings (or (> warning-count 0)
+                      (> error-count 0))})
+
+(defn eastwood
+  ([opts] (eastwood opts (reporting/printing-reporter opts)))
+  ([opts reporter]
+   (try
+     (reporting/note reporter (version/version-string))
+     (let [{:keys [exclude-namespaces
+                   namespaces
+                   source-paths
+                   test-paths
+                   cwd] :as opts} (last-options-map-adjustments opts reporter)
+           namespaces-info (effective-namespaces exclude-namespaces namespaces
+                                               (setup-lint-paths source-paths test-paths))
+           linter-info (select-keys opts [:linters :exclude-linters :add-linters :disable-linter-name-checks])]
+       (reporting/debug reporter :var-info (with-out-str
+                                             (util/print-var-info-summary @typos/var-info-map-delayed opts)))
+       (reporting/debug reporter :compare-forms
+                        "Writing files forms-read.txt and forms-emitted.txt")
+       (->> (effective-linters linter-info linter-name->info default-linters)
+            (eastwood-core reporter opts cwd namespaces-info)
+            summary
+            counted-summary
+            (make-report reporter)))
+     (catch Exception e
+       (reporting/show-error reporter (ex-data e))
+       {:some-warnings true}))))
 
 (defn eastwood-from-cmdline [opts]
   (let [ret (eastwood opts)]
@@ -821,32 +575,31 @@ Keys in a warning map:
   :file - string containing resource name, relative to some
       unspecified path in the Java classpath,
       e.g. \"testcases/f02.clj\""
-  [opts]
-  (let [lint-warnings (atom [])
-        cb (fn cb [info]
-             (case (:kind info)
-               :lint-warning (swap! lint-warnings conj (:warn-data info))
-               :default))  ; do nothing with other kinds of callbacks
-        opts (if (contains? opts :callback)
-               opts
-               (assoc opts :callback cb))
-
-        opts (last-options-map-adjustments opts)
-        _ (when (util/debug? :options opts)
-            (println "\nOptions map after filling in defaults:")
-            (pp/pprint (into (sorted-map) opts)))
-
-        {:keys [err err-data] :as ret} (eastwood-core opts)]
-    {:warnings @lint-warnings
-     :err err
-     :err-data err-data
-     :versions
-     {:eastwood-version-map *eastwood-version*
-      :eastwood-version-string (eastwood-version)
-      :clojure-version-map *clojure-version*
-      :clojure-version-string (clojure-version)
-      :jvm-version-string (get (System/getProperties) "java.version")}}))
-
+  ([opts] (lint opts (reporting/silent-reporter opts)))
+  ([opts reporter]
+   (try
+     (let [{:keys [exclude-namespaces
+                   namespaces
+                   source-paths
+                   test-paths
+                   cwd] :as opts} (last-options-map-adjustments opts reporter)
+           namespaces-info (effective-namespaces exclude-namespaces namespaces
+                                               (setup-lint-paths source-paths test-paths))
+           linter-info (select-keys opts [:linters :exclude-linters :add-linters :disable-linter-name-checks])
+           {:keys [error error-data
+                   lint-warnings
+                   namespace] :as ret}
+           (->> (effective-linters linter-info linter-name->info default-linters)
+                (eastwood-core reporter opts cwd namespaces-info)
+                summary)]
+       {:namespaces namespace
+        :warnings (seq lint-warnings)
+        :err error
+        :err-data error-data
+        :versions (version/versions)})
+     (catch Exception e
+       {:err (ex-data e)
+        :versions (version/versions)}))))
 
 (defn insp
   "Read, analyze, and eval a file specified by namespace as a symbol,

--- a/src/eastwood/linters/implicit_dependencies.clj
+++ b/src/eastwood/linters/implicit_dependencies.clj
@@ -39,6 +39,7 @@
                             (not (within-other-ns-macro? expr ns-sym)))
                    (let [implicit-ns-sym (var->ns-symbol (:var expr))]
                      (when (not (namespace-dependency? implicit-ns-sym))
+;                       (println "META " (util/enclosing-macros expr))
                        {:linter :implicit-dependencies
                         :loc (:env expr)
                         :implicit-namespace-sym implicit-ns-sym

--- a/src/eastwood/reporting_callbacks.clj
+++ b/src/eastwood/reporting_callbacks.clj
@@ -1,110 +1,116 @@
 (ns eastwood.reporting-callbacks
   (:require [clojure.java.io :as io]
-            [clojure.pprint :as pp]
-            [eastwood.util :as util]
-            [clojure.string :as str]))
-
-(defn assert-keys [m key-seq]
-  (assert (util/has-keys? m key-seq)))
-
-
-(defn make-default-msg-cb [wrtr]
-  (fn default-msg-cb [info]
-    (binding [*out* wrtr]
-      (println (:msg info))
-      (flush))))
-
-
-;; Use the option :warning-format :map-v1 to get linter warning maps
-;; as they were generated in Eastwood 0.1.0 thru 0.1.4, intended only
-;; for comparing output from later versions against those versions
-;; more easily.
+            [clojure.string :as str]
+            [eastwood.error-messages :as msgs]
+            [eastwood.util :as util]))
 
 (def last-cwd-shown (atom nil))
 
-(def empty-ordered-lint-warning-map-v1
-  (util/ordering-map [:linter
-                      :msg
-                      :file
-                      :line
-                      :column]))
+(defn print-warning [{:keys [warn-data] :as info} cwd]
+  (when (not= cwd @last-cwd-shown)
+    (reset! last-cwd-shown cwd)
+    (println (format "Entering directory `%s'" cwd)))
+  (println (format "%s:%s:%s: %s: %s"
+                   (-> warn-data :uri-or-file-name str)
+                   ;; Emacs compilation-mode default regex's
+                   ;; do not recognize warning lines with
+                   ;; nil instead of decimal numbers for
+                   ;; line/col number.  Make up values if we
+                   ;; don't know them.
+                   (or (-> warn-data :line) "1")
+                   (or (-> warn-data :column) "1")
+                   (name (-> warn-data :linter))
+                   (-> warn-data :msg))))
 
-(def empty-ordered-lint-warning-map-v2
-  (util/ordering-map [:file
-                      :line
-                      :column
-                      :linter
-                      :msg
-                      :uri-or-file-name]))
+(defrecord PrintingReporter [opts warn-writer])
 
-(defn make-default-lint-warning-cb [wrtr]
-  (fn default-lint-warning-cb [info]
-    (binding [*out* wrtr]
-      (let [warning-format (or (-> info :opt :warning-format)
-                               :location-list-v1)
-            i (case warning-format
-                :map-v1 (into empty-ordered-lint-warning-map-v1
-                              (select-keys (:warn-data info)
-                                           [:linter :msg :file :line :column]))
-                :map-v2 (into empty-ordered-lint-warning-map-v2
-                              (select-keys (:warn-data info)
-                                           [:linter :msg :file :line :column
-                                            :uri-or-file-name
-                                            ;; :uri
-                                            ;; :namespace-sym
-                                            ]))
-                :location-list-v1 (:warn-data info))]
-        (if (= warning-format :location-list-v1)
-          (do
-            (let [cwd (-> info :opt :cwd)]
-              (when (not= cwd @last-cwd-shown)
-                (reset! last-cwd-shown cwd)
-                (println (format "Entering directory `%s'" cwd))))
-            (println (format "%s:%s:%s: %s: %s"
-                             (-> i :uri-or-file-name str)
-                             ;; Emacs compilation-mode default regex's
-                             ;; do not recognize warning lines with
-                             ;; nil instead of decimal numbers for
-                             ;; line/col number.  Make up values if we
-                             ;; don't know them.
-                             (or (-> i :line) "1")
-                             (or (-> i :column) "1")
-                             (name (-> i :linter))
-                             (-> i :msg))))
-          (do
-            (pp/pprint i)
-            (println)
-            (flush)))))))
+(defrecord SilentReporter [opts])
 
-(defn assert-cb-has-proper-keys [info]
-  (case (:kind info)
-    :error     (assert-keys info [:msg :opt])
-    :lint-warning (assert-keys info [:warn-data])
-    :note      (assert-keys info [:msg :opt])
-    :debug     (assert-keys info [:msg :opt])))
+(defn printing-reporter [opts]
+  (let [wrtr (java.io.PrintWriter. *out* true)
+        warn-wrtr (if-let [out (:out opts)]
+                    (io/writer out)
+                    wrtr)]
+    (->PrintingReporter opts warn-wrtr)))
 
-(defn make-eastwood-cb [{:keys [error lint-warning note
-                                eval-out eval-err
-                                debug debug-ast
-                                debug-form-read debug-form-analyzed
-                                debug-form-emitted]}]
-  (fn eastwood-cb [info]
-    (assert-cb-has-proper-keys info)
-    (case (:kind info)
-      :error     (error info)
-      :lint-warning (lint-warning info)
-      :note      (note info)
-      :debug     (debug info))))
+(defn silent-reporter [opts]
+  (->SilentReporter opts))
 
-(defn make-default-cb [opts]
-  (let [;;wrtr (io/writer "east-out.txt")   ; see comment above
-        wrtr (java.io.PrintWriter. *out* true)
-        warn-wrtr (if (contains? opts :out)
-                    (io/writer (:out opts))
-                    wrtr)
-        default-msg-cb (make-default-msg-cb wrtr)
-        default-lint-warning-cb (make-default-lint-warning-cb warn-wrtr)]
-    (make-eastwood-cb {:error default-msg-cb
-                       :lint-warning default-lint-warning-cb
-                       :note default-msg-cb
-                       :debug default-msg-cb})))
+(defn debug [reporter thing msg]
+  (when (util/debug? thing (:opts reporter))
+    (println msg)))
+
+(defn error [reporter e]
+  (println "Linting failed:")
+  (util/pst e nil)
+  (flush)
+  e)
+
+(defn dispatch-fn [record & _]
+  (type record))
+
+(defmulti lint-warning dispatch-fn)
+(defmulti analyzer-exception dispatch-fn)
+(defmulti note dispatch-fn)
+
+(defmethod lint-warning PrintingReporter [reporter warning]
+  (binding [*out* (:warn-writer reporter)]
+    (print-warning warning (-> reporter :opts :cwd))
+    (flush)))
+
+(defmethod analyzer-exception PrintingReporter [reporter exception]
+  (println (str/join "\n" (:msgs exception)))
+  (flush))
+
+(defmethod note PrintingReporter [reporter msg]
+  (println msg)
+  (flush))
+
+(defmethod note SilentReporter [reporter msg] )
+
+(defmethod lint-warning SilentReporter [reporter warning])
+
+(defmethod analyzer-exception SilentReporter [reporter exception])
+
+(defn lint-warnings [reporter warnings]
+  (doseq [warning warnings]
+    (lint-warning reporter warning)))
+
+(defn lint-errors [reporter namespace errors]
+  (doseq [{:keys [exception warn-data] :as error} errors]
+    (when exception
+      (let [{:keys [msgs]} (msgs/format-exception namespace exception)]
+        (doseq [msg msgs]
+          (note reporter msg))))))
+
+(defn show-error [reporter error-data]
+  (when error-data
+    (let [message (msgs/error-msg error-data)]
+      (note reporter message))))
+
+(defn show-analyzer-exception [reporter namespace exception]
+  (when-let [error (first exception)]
+    (doseq [msg (:msgs (first exception))]
+      (note reporter msg))))
+
+(defn report-result [reporter result]
+  (let [namespace (first (:namespace result))]
+    (lint-warnings reporter (:lint-warnings result))
+    (lint-errors reporter namespace (:lint-errors result))
+    (show-analyzer-exception reporter namespace (:analyzer-exception result))))
+
+(defn stopped-on-exception [reporter namespaces results result]
+  (let [namespace (first (:namespace result))
+        processed-namespaces (->> results (map :namespace) (filter identity))]
+    (show-analyzer-exception reporter namespace (:analyzer-exception result))
+    (show-error reporter (:lint-runtime-exception result))
+    (let [error {:err :exception-thrown
+                 :err-data {:last-namespace namespace
+                            :namespaces-left (- (count namespaces)
+                                                (count processed-namespaces))}}]
+      (note reporter (msgs/error-msg error)))))
+
+(defn debug-namespaces [reporter namespaces]
+  (debug reporter :ns (format "Namespaces to be linted:"))
+  (doseq [n namespaces]
+    (debug reporter :ns (format "    %s" n))))

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -97,7 +97,44 @@ return value followed by the time it took to evaluate in millisec."
     {:uri uri
      :uri-or-file-name uri-or-rel-file-str}))
 
+(defn canonical-filename
+  "Returns the canonical file name for the given file name.  A
+canonical file name is platform dependent, but is both absolute and
+unique.  See the Java docs for getCanonicalPath for some more details,
+and the examples below.
 
+    http://docs.oracle.com/javase/7/docs/api/java/io/File.html#getCanonicalPath%28%29
+
+Examples:
+
+Context: A Linux or Mac OS X system, where the current working
+directory is /Users/jafinger/clj/dolly
+
+user=> (canonical-filename \"README.md\")
+\"/Users/jafinger/clj/dolly/README.md\"
+
+user=> (canonical-filename \"../../Documents/\")
+\"/Users/jafinger/Documents\"
+
+user=> (canonical-filename \"../.././clj/../Documents/././\")
+\"/Users/jafinger/Documents\"
+
+Context: A Windows 7 system, where the current working directory is
+C:\\Users\\jafinger\\clj\\dolly
+
+user=> (canonical-filename \"README.md\")
+\"C:\\Users\\jafinger\\clj\\dolly\\README.md\"
+
+user=> (canonical-filename \"..\\..\\Documents\\\")
+\"C:\\Users\\jafinger\\Documents\"
+
+user=> (canonical-filename \"..\\..\\.\\clj\\..\\Documents\\.\\.\\\")
+\"C:\\Users\\jafinger\\Documents\""
+  [fname]
+  (let [^java.io.File f (if (instance? java.io.File fname)
+                          fname
+                          (java.io.File. ^String fname))]
+    (.getCanonicalPath f)))
 
 
 ;; Copied from clojure.repl/pst then modified to 'print' using a
@@ -105,26 +142,22 @@ return value followed by the time it took to evaluate in millisec."
 
 (defn pst
   "'Prints' a stack trace of the exception,  to the depth requested (the
-entire stack trace if depth is nil).  Does not print ex-data.
-
-No actual printing is done in this function.  The callback function
-print-cb is called once for each line of output."
-  [^Throwable e depth print-cb]
-  (print-cb (str (-> e class .getSimpleName) " "
+entire stack trace if depth is nil).  Does not print ex-data."
+  [^Throwable e depth]
+  (println (str (-> e class .getSimpleName) " "
                  (.getMessage e)))
   (let [st (.getStackTrace e)
         cause (.getCause e)]
     (doseq [el (remove #(#{"clojure.lang.RestFn" "clojure.lang.AFn"}
                          (.getClassName ^StackTraceElement %))
                        st)]
-      (print-cb (str \tab (repl/stack-element-str el))))
+      (println (str \tab (repl/stack-element-str el))))
     (when cause
-      (print-cb "Caused by:")
+      (println "Caused by:")
       (pst cause (if depth
                    (min depth
                         (+ 2 (- (count (.getStackTrace cause))
-                                (count st)))))
-           print-cb))))
+                                (count st)))))))))
 
 
 ;; ordering-map copied under Eclipse Public License v1.0 from useful
@@ -731,10 +764,7 @@ of these kind."
        not-found)))
 
 (defn debug? [debug-options opt]
-  {:pre [(or (keyword? debug-options) (set? debug-options))
-         (map? opt)
-         (set? (:debug opt))]}
-  (let [d (:debug opt)]
+  (when-let [d (:debug opt)]
     (or (contains? d :all)
         (and (set? debug-options)
              (some debug-options d))
@@ -845,12 +875,11 @@ StringWriter."
               (println "(none specified to debug-warning fn)")))))))))
 
 
-(def ^:private warning-enable-config-atom (atom []))
-
+;; This atom is modified from the config files
+(def warning-enable-config-atom (atom []))
 
 (defn disable-warning [m]
   (swap! warning-enable-config-atom conj m))
-
 
 (defn process-configs [warning-enable-config]
   (reduce (fn [configs {:keys [linter] :as m}]
@@ -875,23 +904,19 @@ StringWriter."
   (io/resource (str "eastwood/config/" name)))
 
 
-(defn init-warning-enable-config [opt]
-  (let [builtin-config-files (:builtin-config-files opt)
-        other-config-files (get opt :config-files [])
-        config-files (concat (map builtin-config-to-resource
-                                  builtin-config-files)
-                             other-config-files)
-        error-cb (make-msg-cb :error opt)
-        debug-cb (make-msg-cb :debug opt)]
-    (doseq [config-file config-files]
+(defn init-warning-enable-config [builtin-config-files config-files opt]
+  (let [all-config-files (concat (map builtin-config-to-resource
+                                      builtin-config-files)
+                                 config-files)]
+    (doseq [config-file all-config-files]
       (when (debug? :config opt)
-        (debug-cb (format "Loading config file: %s" config-file)))
+        (println (format "Loading config file: %s" config-file)))
       (try
         (binding [*ns* (the-ns 'eastwood.util)]
           (load-reader (io/reader config-file)))
         (catch Exception e
-          (error-cb (format "Exception while attempting to load config file: %s" config-file))
-          (pst e nil error-cb))))
+          (println (format "Exception while attempting to load config file: %s" config-file))
+          (pst e nil))))
     (process-configs @warning-enable-config-atom)))
 
 

--- a/src/eastwood/version.clj
+++ b/src/eastwood/version.clj
@@ -16,3 +16,22 @@
         (def string (str (join "." (filter identity [major minor patch]))
                          (when pre-release (str "-" pre-release))
                          (when build (str "+" build))))))))
+
+(def ^:dynamic *eastwood-version*
+  {:major major, :minor minor, :incremental patch, :qualifier pre-release})
+
+(defn eastwood-version [] string)
+
+(defn versions []
+  {:eastwood-version-map *eastwood-version*
+   :eastwood-version-string (eastwood-version)
+   :clojure-version-map *clojure-version*
+   :clojure-version-string (clojure-version)
+   :jvm-version-string (get (System/getProperties) "java.version")})
+
+(defn version-string []
+  (let [versions (versions)]
+    (format "== Eastwood %s Clojure %s JVM %s =="
+            (:eastwood-version-string versions)
+            (:clojure-version-string versions)
+            (:jvm-version-string versions))))

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -1,0 +1,72 @@
+(ns eastwood.lint-test
+  (:use [clojure.test ])
+  (:require [eastwood.lint :refer :all]
+            [eastwood.copieddeps.dep11.clojure.java.classpath :as classpath]
+            [eastwood.util :as util]
+            [eastwood.copieddeps.dep9.clojure.tools.namespace.dir :as dir]
+            [eastwood.copieddeps.dep9.clojure.tools.namespace.track :as track]
+            [eastwood.reporting-callbacks :as reporting])
+  (:import java.io.File))
+
+
+(deftest expand-ns-keywords-test
+  (testing ""
+    (is (= ["foo" "bar" "baz"] (expand-ns-keywords {:source-paths ["foo"]} [:source-paths "bar" "baz"])))))
+
+(deftest last-options-map-adjustments-test
+  (let [reporter (reporting/silent-reporter default-opts)]
+    (testing "default-options are added"
+      (is (= default-opts
+             (dissoc (last-options-map-adjustments nil reporter)
+                     :warning-enable-config))))
+    (testing "passed options are respected"
+      (is (= (assoc default-opts
+                    :namespaces #{"foo"})
+             (dissoc (last-options-map-adjustments {:namespaces ["foo"]} reporter)
+                     :warning-enable-config))))
+    (testing "all the things are sets"
+      (is (empty? (->>
+                   (select-keys (last-options-map-adjustments {:namespaces []} reporter) [:debug :namespaces :source-paths :test-paths :exclude-namespaces])
+                   (vals)
+                   (remove set?)))))))
+
+(deftest setup-lint-paths-test
+  (testing "non-empty source/test paths is respected"
+    (is (= {:source-paths #{"lol"}
+            :test-paths #{}}
+           (setup-lint-paths #{"lol"} nil)))
+    (is (= {:source-paths #{}
+            :test-paths #{"lol"}}
+           (setup-lint-paths nil #{"lol"})))
+    (is (= {:source-paths #{"lol"}
+            :test-paths #{"bar"}}
+           (setup-lint-paths #{"lol"} #{"bar"}))))
+  (testing "empty source/test paths yields classpath-directories"
+    (with-redefs [classpath/classpath-directories (fn [] [(File. "lol" )])]
+      (is (= {:source-paths #{(File. "lol")}
+              :test-paths #{}}
+             (setup-lint-paths nil nil))))))
+
+(def eastwood-src-namespaces (::track/load (dir/scan-dirs (track/tracker) #{"src"})))
+(def eastwood-test-namespaces (::track/load (dir/scan-dirs (track/tracker) #{"test"})))
+(def eastwood-all-namespaces (concat eastwood-src-namespaces eastwood-test-namespaces))
+
+(deftest nss-in-dirs-test
+  (let [dirs #{"src"}]
+    (testing "basic functionality"
+      (is (= {:dirs (set (map util/canonical-filename dirs))
+              :namespaces eastwood-src-namespaces}
+             (select-keys (nss-in-dirs dirs) [:dirs :namespaces]))))))
+
+(deftest effective-namespaces-test
+  (let [source-paths #{"src"}
+        test-paths #{"test"}]
+    (testing ""
+      (is (= {:dirs (concat (map util/canonical-filename source-paths)
+                            (map util/canonical-filename test-paths))
+              :namespaces eastwood-all-namespaces}
+             (select-keys (effective-namespaces #{}
+                                                #{:source-paths :test-paths}
+                                                {:source-paths source-paths
+                                                 :test-paths test-paths})
+                          [:dirs :namespaces]))))))

--- a/test/eastwood/test/implicit_dependencies_linter_test.clj
+++ b/test/eastwood/test/implicit_dependencies_linter_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test :refer :all]
             [eastwood.test.linters-test :as linters-test]))
 
-
 (deftest implicit-dependency-linter
   (linters-test/lint-test
    'testcases.implicit_dependencies

--- a/test/eastwood/test/linters_test.clj
+++ b/test/eastwood/test/linters_test.clj
@@ -4,7 +4,8 @@
             [clojure.string :as str]
             [clojure.pprint :as pp]
             [eastwood.util :as util]
-            [eastwood.lint :refer :all])
+            [eastwood.lint :refer :all]
+            [eastwood.reporting-callbacks :as reporting])
   (:import (java.io File)))
 
 ;; TBD: It would be cleaner to make Eastwood's error reporting code
@@ -43,14 +44,15 @@ the next."
                    (compare ((juxt :line :column :linter :msg) w1)
                             ((juxt :line :column :linter :msg) w2)))))
 
-(def default-opts {})
+(def default-test-opts {})
 
 ;; If an exception occurs during analyze, re-throw it.  This will
 ;; cause any test written that calls lint-ns-noprint to fail, unless
 ;; it expects the exception.
 (defn lint-ns-noprint [ns-sym linters opts]
-  (let [opts (assoc opts :linters linters)
-        opts (last-options-map-adjustments opts)
+  (let [opts (assoc opts :linters linters
+                     :debug #{})
+        opts (last-options-map-adjustments opts (reporting/silent-reporter opts))
         cb (fn cb [info]
              (case (:kind info)
                (:eval-out :eval-err) (println (:msg info))
@@ -93,7 +95,7 @@ the next."
    [:misplaced-docstrings :def-in-def :redefd-vars :deprecations
     :wrong-arity :local-shadows-var :wrong-tag :non-dynamic-earmuffs
     :unused-locals]
-   (assoc default-opts
+   (assoc default-test-opts
      ;;:debug [:ns :config]
      :config-files
      [(fname-from-parts "cases" "testcases" "eastwood-testing-config.clj")])


### PR DESCRIPTION
This commit removes most of the callback code used for reporting in
Eastwood, in favour of a set of multimethods found in the
`reporting-callbacks` ns

Also, state-handling has gone from atoms to a more functional
approach, and error handling is now largely done by exceptions rather
than passing maps with magic keys.

An effort has been done to remove the passing of `opts` and rather
extract the needed values from `opts` before calling the next function.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [ ] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)

Thanks!
