### PR TITLE
Support string or map for main opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,12 @@ no more dangerous.  To confine linting to files in your
     $ lein eastwood "{:namespaces [:source-paths]}"
 
 ## deps.edn
-If you're using `deps.edn`, consider merging
+If you're using `deps.edn`, you can set options to eastwood linter in a
+ EDN map, like this:
 ```clojure
 {:aliases
   {:eastwood
-      {:main-opts ["-m" "eastwood.lint" "{:source-paths,[\"src\"]}"]
+      {:main-opts ["-m" "eastwood.lint" {:source-paths ["src"]}]
 	   :extra-deps {jonase/eastwood {:mvn/version "RELEASE"}}}}}
 
 ```

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -644,5 +644,10 @@ clojure.inspector/inspect-tree on it.  Example in REPL:
 
 (defn -main
   ([] (-main (pr-str default-opts)))
-  ([opts]
-   (eastwood-from-cmdline  (edn/read-string opts))))
+  ([& opts]
+   (if (and
+         (= 1 (count opts))
+         (string? (first opts)))
+     (eastwood-from-cmdline (edn/read-string (first opts)))
+     (let [parsed (->> opts (interpose " ") (apply str) edn/read-string)]
+       (eastwood-from-cmdline parsed)))))


### PR DESCRIPTION
The current implementation only supports the main opts to be a string,
which should be a stringified EDN. This patch keeps this feature for
backward compatibility and adds the ability to send a Clojure map
directly. This allows us to declare main-opts in a Clojure deps project
like this:
```
  :main-opts ["-m" "eastwood.lint"
              {:source-paths ["src" "test" "standalone" "dev"]
               :config-files ["resources/eastwood_config.clj"]
               :exclude-linters [:unused-ret-vals]}]}
```
String version is also supported in order to be backward compatible:
```
  :main-opts ["-m" "eastwood.lint" "{:source-paths,[\"src\",\"test\",\"standalone\",\"dev\"],:config-files[\"resources/eastwood_config.clj\"],:exclude-linters[:unused-ret-vals]}"]}
```
