### PR TITLE
Add info on how to use only-modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,14 @@ Currently only a `:naive` form of parallelism is supported, which just uses
 As of version 0.3.5, you can now instruct eastwood to only lint the files
 changed since the last run. This feature is pr 0.3.5 to be considered
 alpha and subject to change.
+If passed `:only-modified` with the value true, Eastwood will only lint the 
+files which are modified since the timestamp stored in `.eastwood`.
+
+```
+  :only-modified true
+```
+
+## Usage
 
 As mentioned in the [Installation & Quick
 usage](#installation--quick-usage) section above, Eastwood causes any


### PR DESCRIPTION
There was no intrinsic link between `:only-modified` flag and the readme text that describes the functionality.

Also the heading implied that the rest of the content was about the same subject, so I added a new misc header.
