### PR TITLE
Reset warning-enable-config-atom before init

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,9 @@
 # Change log for Eastwood
 
+## Changes from 0.3.6 to 0.3.7
+
+ * Fix memory leak on repeated runs
+
 ## Changes from 0.3.5 to 0.3.6
 
 * Add support for files with tagged literals using custom data readers

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -918,6 +918,7 @@ StringWriter."
         (catch Exception e
           (println (format "Exception while attempting to load config file: %s" config-file))
           (pst e nil))))
+    (reset! warning-enable-config-atom [])
     (process-configs @warning-enable-config-atom)))
 
 


### PR DESCRIPTION
Applies suggestion made in #317, solving the issue.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
