### PR TITLE
[WIP] Use analyzer-exception to report exceptions

### DIFF
--- a/src/eastwood/reporting_callbacks.clj
+++ b/src/eastwood/reporting_callbacks.clj
@@ -66,7 +66,7 @@
   (print (str msg "\n"))
   (flush))
 
-(defmethod note SilentReporter [reporter msg] )
+(defmethod note SilentReporter [reporter msg])
 
 (defmethod lint-warning SilentReporter [reporter warning])
 
@@ -92,8 +92,8 @@
 
 (defn show-analyzer-exception [reporter namespace exception]
   (when-let [error (first exception)]
-    (doseq [msg (:msgs (first exception))]
-      (note reporter msg))))
+    (doseq [msg (:msgs error)]
+      (analyzer-exception reporter msg))))
 
 (defn report-result [reporter result]
   (let [namespace (first (:namespace result))]


### PR DESCRIPTION
When implementing a custom reporter I noticed `eastwood.reporting-callbacks/analyzer-exception` isn't called.  `eastwood.reporting-callbacks/show-analyzer-exception` calls `eastwood.reporting-callbacks/note` instead, making it impossible to differentiate between 'notes' and exceptions.

**wip** still investigating what the diff is between show-* and lint-*.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)

Thanks!
