### PR TITLE
[Fix #190] no warnings for dynamic vars in pre/post

### DIFF
--- a/cases/testcases/wrongprepost2.clj
+++ b/cases/testcases/wrongprepost2.clj
@@ -5,3 +5,9 @@
 (defn issue-219-fn [data]
   {:pre [(spec/assert ::my-spec data)]}
   (assoc data 5 7))
+
+(def ^:dynamic *dynvar* nil)
+
+(defn issue-190-fn [x]
+  {:pre [*dynvar*]}
+  x)

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,9 @@
 # Change log for Eastwood
 
+## Changes from 0.3.7 to 0.3.8
+
+ * Fix pre-post warning for dynamic vars
+
 ## Changes from 0.3.6 to 0.3.7
 
  * Fix memory leak on repeated runs

--- a/src/eastwood/linters/typos.clj
+++ b/src/eastwood/linters/typos.clj
@@ -1007,7 +1007,8 @@ warning, that contains the constant value."
         (format "%s found that is always logical true or always logical false.  Should be changed to function call?  %s"
                 condition-desc-begin (pr-str condition))
 
-        (= :var (:op test-ast))
+        (and (-> test-ast :op #{:var})
+             (-> test-ast :var meta :dynamic #{nil false}))
         (format "%s found that is probably always logical true or always logical false.  Should be changed to function call?  %s"
                 condition-desc-begin (pr-str condition))
         


### PR DESCRIPTION
Fixes #190 by ignoring any var marked as dynamic in `prepost`-linter.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [x] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)

Thanks!
