### PR TITLE
Introduce `set-linter-executor!`

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,9 @@
 # Change log for Eastwood
 
+## Changes from 0.3.10 to 0.4.0
+
+ * Add `set-linter-executor!` configuration option
+
 ## Changes from 0.3.7 to 0.3.8
 
  * Fix pre-post warning for dynamic vars

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,8 @@
              :test {:dependencies [
                                    ;; Needed for issue-173-test
                                    [commons-io "2.4"]
-                                   ]}
+                                   ]
+                    :resource-paths ["test-resources"]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -165,7 +165,7 @@
      :analysis-time elapsed
      :lint-results (some->> linters
                             (keep linter-name->info)
-                            (map (partial lint-ns* ns-sym analyze-results opts)))
+                            (@util/linter-executor-atom (partial lint-ns* ns-sym analyze-results opts)))
      :analyzer-exception (when exception
                            (msgs/report-analyzer-exception exception exception-phase exception-form ns-sym))}))
 

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -882,6 +882,15 @@ StringWriter."
 (defn disable-warning [m]
   (swap! warning-enable-config-atom conj m))
 
+(def linter-executor-atom
+  "A `#'map`-like function that will run each of the linters.
+
+  Can be customized in order to achieve linter parallelism, or extra logging, etc."
+  (atom map))
+
+(defn set-linter-executor! [executor]
+  (reset! linter-executor-atom executor))
+
 (defn process-configs [warning-enable-config]
   (reduce (fn [configs {:keys [linter] :as m}]
             (case linter
@@ -910,6 +919,7 @@ StringWriter."
                                       builtin-config-files)
                                  config-files)]
     (reset! warning-enable-config-atom [])
+    (reset! linter-executor-atom map)
     (doseq [config-file all-config-files]
       (when (debug? :config opt)
         (println (format "Loading config file: %s" config-file)))

--- a/test-resources/eastwood/config/linter_executor.clj
+++ b/test-resources/eastwood/config/linter_executor.clj
@@ -1,0 +1,7 @@
+(defn custom-map [f & colls]
+  (swap! @(resolve 'eastwood.linter-executor-test/proof)
+         conj
+         :hello)
+  (apply map f colls))
+
+(set-linter-executor! custom-map)

--- a/test-resources/eastwood/test/linter_executor/sample_ns.clj
+++ b/test-resources/eastwood/test/linter_executor/sample_ns.clj
@@ -1,0 +1,4 @@
+(ns eastwood.test.linter-executor.sample-ns)
+
+;; trigger at least 1 warning:
+(-> 1)

--- a/test/eastwood/linter_executor_test.clj
+++ b/test/eastwood/linter_executor_test.clj
@@ -1,0 +1,22 @@
+(ns eastwood.linter-executor-test
+  (:require [clojure.test :refer :all]
+            [eastwood.lint]))
+
+(def proof (atom []))
+
+(deftest works
+  (are [desc input pred] (testing [desc input]
+                           (reset! proof [])
+                           (with-out-str
+                             (eastwood.lint/eastwood {:namespaces ['eastwood.test.linter-executor.sample-ns]
+                                                      :builtin-config-files input}))
+                           (is (pred @proof))
+                           ;; Avoid duplicate failure reports, did the tests fail:
+                           true)
+    "The custom `set-linter-executor!` successfully runs"
+    ["linter_executor.clj"]
+    seq
+
+    "The effect of custom `:builtin-config-files` is not persistent"
+    []
+    empty?))


### PR DESCRIPTION
This PR introduces `set-linter-executor!` so that I can test out my tentative linter parallellism for a few weeks.

For extra context, I run Eastwood through a [rather heavy](https://github.com/nedap/formatting-stack/blob/5c6e1f11c6ec80475063df52e1aceaded8375aee/.circleci/config.yml) CI pipeline :)

Part of jonase/eastwood#339

---

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
