### PR TITLE
Fix a missing quote in a code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ as deprecated without breaking the build.
 ```clojure
 (disable-warning
   {:linter :deprecations
-   :symbol-matches #{#"^#'my\.old\.project\.*}})
+   :symbol-matches #{#"^#'my\.old\.project\.*"}})
 ```
 
 Eastwood would normally report a `:suspicious-expression` warning if


### PR DESCRIPTION
The example config source has a missing `"`. This fixes it.