### PR TITLE
Introduce `:rethrow-exceptions?` option

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,10 @@
 # Change log for Eastwood
 
+## Changes from 0.3.11 to 0.3.12
+
+* Introduce `:rethrow-exceptions?` option, which offers throwing any encountered exceptions during analysis/linting instead of only reporting them.
+You might want this if using Eastwood programatically.
+
 ## Changes from 0.3.10 to 0.3.11
 
  * Add `set-linter-executor!` configuration option

--- a/test-resources/invalid/syntax.clj
+++ b/test-resources/invalid/syntax.clj
@@ -1,0 +1,3 @@
+(ns invalid.syntax)
+
+(

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -70,3 +70,20 @@
                                                 {:source-paths source-paths
                                                  :test-paths test-paths} 0)
                           [:dirs :namespaces]))))))
+
+(deftest exceptions-test
+  (let [valid-namespaces   (take 1 eastwood-src-namespaces)
+        invalid-namespaces '[invalid.syntax]]
+    (are [namespaces rethrow-exceptions? ok?] (testing [namespaces rethrow-exceptions?]
+                                                (try
+                                                  (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces namespaces :rethrow-exceptions? rethrow-exceptions?))
+                                                  (is ok?)
+                                                  (catch Exception _
+                                                    (is (not ok?))))
+                                                true)
+      []                 false true
+      []                 true  true
+      invalid-namespaces false true
+      invalid-namespaces true  false
+      valid-namespaces   true  true
+      valid-namespaces   false true)))


### PR DESCRIPTION
github.com/nedap/formatting-stack offers eastwood integration, we got a report of an unreported exception (https://github.com/nedap/formatting-stack/issues/159). 

I initially tried to fix it in this PR #332, but I deemed that too invasive as it was a breaking change.

The `:rethrow-exceptions?` option offers throwing any encountered exceptions during analysis/linting instead of only reporting them.


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)

Thanks!
