### PR TITLE
Fix `:rethrow-exceptions?`-bug

### DIFF
--- a/src/eastwood/reporting_callbacks.clj
+++ b/src/eastwood/reporting_callbacks.clj
@@ -102,6 +102,12 @@
     (show-analyzer-exception reporter namespace (:analyzer-exception result))
     result))
 
+(defn maybe-wrap-in-ex-info [x]
+  (if (instance? Throwable x)
+    x
+    (ex-info (str ::stopped-on-exception)
+             x)))
+
 (defn stopped-on-exception [reporter
                             namespaces
                             results
@@ -117,8 +123,8 @@
                                                 (count processed-namespaces))}}]
       (note reporter (msgs/error-msg error)))
     (when rethrow-exceptions?
-      (some-> analyzer-exception first throw)
-      (some-> lint-runtime-exception first throw))))
+      (some-> analyzer-exception first maybe-wrap-in-ex-info throw)
+      (some-> lint-runtime-exception first maybe-wrap-in-ex-info throw))))
 
 (defn debug-namespaces [reporter namespaces]
   (debug reporter :ns (format "Namespaces to be linted:"))


### PR DESCRIPTION
Since #348 we noticed the exceptions are sometimes wrapped in a hashmap, which cannot be thrown. The presence of a `:exception`-key is not guaranteed, so `maybe-wrap-in-ex-info` was added to wrap the hashmap in ex-info.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [ ] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)

Thanks!
