### PR TITLE
Keep order for `:namespaces`-option

### DIFF
--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -460,10 +460,13 @@ Return value:
                    :rethrow-exceptions? false})
 
 (defn last-options-map-adjustments [opts reporter]
-  (let [opts (merge default-opts opts)
+  (let [{:keys [namespaces] :as opts} (merge default-opts opts)
+        distinct* (fn [x] ;; distinct but keeps original coll type
+                    (->> (into (empty x) (distinct) x)
+                         (into (empty x)))) ;; restore list order
         opts (-> opts
                  (update :debug set)
-                 (update :namespaces set)
+                 (update :namespaces distinct*)
                  (update :source-paths set)
                  (update :test-paths set)
                  (update :exclude-namespaces set))

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -19,14 +19,22 @@
       (is (= default-opts
              (dissoc (last-options-map-adjustments nil reporter)
                      :warning-enable-config))))
-    (testing "passed options are respected"
+    (testing "passed options are respected. So are the type and sort order of :namespaces."
+      (is (= (assoc default-opts
+                    :namespaces ["foo" "bar"])
+             (dissoc (last-options-map-adjustments {:namespaces ["foo" "bar"]} reporter)
+                     :warning-enable-config)))
       (is (= (assoc default-opts
                     :namespaces #{"foo"})
-             (dissoc (last-options-map-adjustments {:namespaces ["foo"]} reporter)
+             (dissoc (last-options-map-adjustments {:namespaces #{"foo"}} reporter)
+                     :warning-enable-config)))
+      (is (= (assoc default-opts
+                    :namespaces '("foo" "bar"))
+             (dissoc (last-options-map-adjustments {:namespaces '("foo" "bar")} reporter)
                      :warning-enable-config))))
-    (testing "all the things are sets"
+    (testing "all the things are sets (except :namespaces, which keep their original class)"
       (is (empty? (->>
-                   (select-keys (last-options-map-adjustments {:namespaces []} reporter) [:debug :namespaces :source-paths :test-paths :exclude-namespaces])
+                   (select-keys (last-options-map-adjustments {:namespaces []} reporter) [:debug :source-paths :test-paths :exclude-namespaces])
                    (vals)
                    (remove set?)))))))
 

--- a/test/eastwood/test/linters_test.clj
+++ b/test/eastwood/test/linters_test.clj
@@ -2180,7 +2180,7 @@ the next."
      default-opts
      {{:linter :duplicate-params,
        :msg
-       "Local name a occurs multiple times in the same argument vector",
+       "Local name `a` occurs multiple times in the same argument vector",
        :file "testcases/duplicateparams2.clj",
        :line 7,
        :column 48}


### PR DESCRIPTION
This allows to use topological dependency order, avoiding unlucky code loading by tools.analyzer.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [ ] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)

Thanks!
Passing a vector of :namespaces allows to use a topological dependency order, avoiding unlucky code loading by tools.analyzer