### PR TITLE
Improve `:implicit-dependencies` to support potemkin

### DIFF
--- a/cases/testcases/f08.clj
+++ b/cases/testcases/f08.clj
@@ -1,0 +1,7 @@
+(ns testcases.f08
+  "Testcase for issue 307. It uses a dependency with an imported var"
+  (:require
+   [testcases.imported-var :as imported-var]))
+
+(imported-var/join "z")
+

--- a/cases/testcases/imported_var.clj
+++ b/cases/testcases/imported_var.clj
@@ -1,0 +1,8 @@
+(ns testcases.imported-var
+  "mimics a var imported from another namespace. i.e. by potemkin/import-vars"
+  (:require [clojure.string :as str]))
+
+(def join
+  str/join)
+
+(alter-meta! #'join merge (meta #'str/join))

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,14 @@
 # Change log for Eastwood
 
+## Changes from 0.3.13 to 
+
+* Improve `:implicit-dependencies` to support potemkin/import-vars
+
+## Changes from 0.3.12 to 0.3.13
+
+* Fix `:rethrow-exceptions?` option which could try to hash-map
+* Keep order for `:namespaces` option
+
 ## Changes from 0.3.11 to 0.3.12
 
 * Introduce `:rethrow-exceptions?` option, which offers throwing any encountered exceptions during analysis/linting instead of only reporting them.

--- a/src/eastwood/linters/implicit_dependencies.clj
+++ b/src/eastwood/linters/implicit_dependencies.clj
@@ -5,8 +5,7 @@
 
 
 (defn var->ns-symbol [var]
-  (let [^clojure.lang.Namespace ns (-> var meta :ns)]
-    (.-name ns)))
+  (symbol (namespace (symbol var))))
 
 
 (defn within-other-ns-macro?

--- a/test/eastwood/test/implicit_dependencies_linter_test.clj
+++ b/test/eastwood/test/implicit_dependencies_linter_test.clj
@@ -13,4 +13,9 @@
      :file "testcases/implicit_dependencies.clj",
      :line 4,
      :column 3}
-    1}))
+    1})
+  (linters-test/lint-test
+   'testcases.f08
+   [:implicit-dependencies]
+   {}
+   {}))


### PR DESCRIPTION
e.g. imported using #'potemkin/import-vars. fixes #307 as suggested [here](https://github.com/jonase/eastwood/issues/307#issuecomment-764304379)

I verified this change by loading eastwood with `[clojure.java-time "0.3.2"]` on it's classpath, and analyzing `(ns test (:require [java-time]))`;

First execution is against current master, second execution is against this fix.
![image](https://user-images.githubusercontent.com/4689114/105409620-fbf11b00-5c30-11eb-98c2-4a2bd84f4a16.png)


**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)

Thanks!
