### PR TITLE
`linters.unused`: account for imported classes

### DIFF
--- a/cases/testcases/unusednsimport/consumer1.clj
+++ b/cases/testcases/unusednsimport/consumer1.clj
@@ -1,0 +1,7 @@
+(ns testcases.unusednsimport.consumer1
+  ;; This require is needed to properly import the record below
+  (:require [testcases.unusednsimport.defrecord])
+  (:import (testcases.unusednsimport.defrecord A)))
+
+;; Exercises top-level forms:
+(A. 1)

--- a/cases/testcases/unusednsimport/consumer2.clj
+++ b/cases/testcases/unusednsimport/consumer2.clj
@@ -1,0 +1,8 @@
+(ns testcases.unusednsimport.consumer2
+  ;; This require is needed to properly import the record below
+  (:require [testcases.unusednsimport.defrecord])
+  (:import (testcases.unusednsimport.defrecord A)))
+
+;; Should be deemed unused:
+(comment
+  (A. 1))

--- a/cases/testcases/unusednsimport/consumer3.clj
+++ b/cases/testcases/unusednsimport/consumer3.clj
@@ -1,0 +1,9 @@
+(ns testcases.unusednsimport.consumer3
+  ;; This require is needed to properly import the record below
+  (:require [testcases.unusednsimport.defrecord])
+  (:import (testcases.unusednsimport.defrecord A)))
+
+;; Exercises forms nested deep into arbitrary code:
+(defn sample []
+  (for [x [(A. 1)]]
+    x))

--- a/cases/testcases/unusednsimport/consumer4.clj
+++ b/cases/testcases/unusednsimport/consumer4.clj
@@ -1,0 +1,9 @@
+(ns testcases.unusednsimport.consumer4
+  ;; This require is needed to properly import the record below
+  (:require [testcases.unusednsimport.defrecord])
+  (:import (testcases.unusednsimport.defrecord A)))
+
+;; Exercises metadata:
+(defn ^A sample []
+  ;; return nil (and not `(A.)` so that we are certain that only metadata is being exercised)
+  nil)

--- a/cases/testcases/unusednsimport/consumer5.clj
+++ b/cases/testcases/unusednsimport/consumer5.clj
@@ -1,0 +1,7 @@
+(ns testcases.unusednsimport.consumer5
+  ;; This require is needed to properly import the record below
+  (:require [testcases.unusednsimport.defrecord])
+  (:import (testcases.unusednsimport.defrecord A)))
+
+;; Exercises simple defs:
+(def thing (A. 1))

--- a/cases/testcases/unusednsimport/defrecord.clj
+++ b/cases/testcases/unusednsimport/defrecord.clj
@@ -1,0 +1,3 @@
+(ns testcases.unusednsimport.defrecord)
+
+(defrecord A [a])

--- a/src/eastwood/linters/unused.clj
+++ b/src/eastwood/linters/unused.clj
@@ -64,14 +64,11 @@
       symbol))
 
 (defn classes-used [asts]
-  (let [simple-tags (->> asts
-                         (mapcat ast/nodes)
-                         (keep :o-tag))
-        tags-from-meta (->> asts
-                            (mapcat ast/nodes)
-                            (keep (comp :tag meta :result)))
+  (let [nodes (mapcat ast/nodes asts)
+        simple-tags (keep :o-tag nodes)
+        tags-from-meta (keep (comp :tag meta :result)
+                             nodes)
         tags (into simple-tags tags-from-meta)]
-    
     (into #{}
           (remove nil?)
           tags)))

--- a/src/eastwood/linters/unused.clj
+++ b/src/eastwood/linters/unused.clj
@@ -63,6 +63,19 @@
       (str/replace #"\.[^\.]+$" "")
       symbol))
 
+(defn classes-used [asts]
+  (let [simple-tags (->> asts
+                         (mapcat ast/nodes)
+                         (keep :o-tag))
+        tags-from-meta (->> asts
+                            (mapcat ast/nodes)
+                            (keep (comp :tag meta :result)))
+        tags (into simple-tags tags-from-meta)]
+    
+    (into #{}
+          (remove nil?)
+          tags)))
+
 (defn protocols-used [asts]
   (->> asts
        (mapcat ast/nodes)
@@ -267,6 +280,7 @@ Example: (all-suffixes [1 2 3])
         used-keywords (keywords-used asts)
         used-macros (macros-invoked asts)
         used-protocols (protocols-used asts)
+        used-classes (classes-used asts)
 ;;        _ (do
 ;;            (println "dbg: required namespaces:")
 ;;            (pp/pprint required)
@@ -302,7 +316,8 @@ Example: (all-suffixes [1 2 3])
                                       (map symbol))
                                  (keep #(if-let [n (namespace %)] (symbol n))
                                        used-macros)
-                                 (map namespace-for used-protocols)))]
+                                 (map namespace-for used-protocols)
+                                 (map namespace-for used-classes)))]
     (for [ns (set/difference required used-namespaces)]
       {:loc loc
        :unused-namespace-sym ns

--- a/test/eastwood/test/linters_test.clj
+++ b/test/eastwood/test/linters_test.clj
@@ -1708,6 +1708,23 @@ the next."
      :line 164, :column 1}
     1,
     })
+  ;; No faults expected:
+  (lint-test 'testcases.unusednsimport.consumer1 [:unused-namespaces] default-opts {})
+  ;; Fault expected (since the refered type is in a `comment` form):
+  (lint-test 'testcases.unusednsimport.consumer2
+             [:unused-namespaces]
+             default-opts
+             {{:linter :unused-namespaces
+               :msg "Namespace testcases.unusednsimport.defrecord is never used in testcases.unusednsimport.consumer2"
+               :file "testcases/unusednsimport/consumer2.clj"
+               :line 1
+               :column 1} 1})
+  ;; No faults expected:
+  (lint-test 'testcases.unusednsimport.consumer3 [:unused-namespaces] default-opts {})
+  ;; No faults expected:
+  (lint-test 'testcases.unusednsimport.consumer4 [:unused-namespaces] default-opts {})
+  ;; No faults expected:
+  (lint-test 'testcases.unusednsimport.consumer5 [:unused-namespaces] default-opts {})
   (lint-test
    'testcases.unusednss
    [:unused-namespaces :unused-locals]


### PR DESCRIPTION
Fixes jonase/eastwood#210
Closes https://github.com/jonase/eastwood/pull/351