### PR TITLE
Hide a println under the :debug mechanism

### DIFF
--- a/src/eastwood/passes.clj
+++ b/src/eastwood/passes.clj
@@ -46,12 +46,6 @@
         arg-type-arr (into-array Class arg-type-vec)]
 ;;    (println (format "dbgx: get-method cls=%s method=%s arg-types=%s"
 ;;                     cls method-name (arg-type-str arg-type-vec)))
-    (when (some nil? arg-type-vec)
-      (println (format "Error: Bad arg-type nil for method named %s for class %s, full arg type list (%s).  ast pprinted below for debugging tools.analyzer:"
-                       method-name
-                       (.getName ^Class cls)
-                       (arg-type-str arg-type-vec)))
-      (util/pprint-ast-node ast))
     (try
       (.getMethod ^Class cls method-name arg-type-arr)
       (catch NoSuchMethodException e


### PR DESCRIPTION
Fixes https://github.com/jonase/eastwood/issues/355

This `println` was confusing. The reflection warnings mechanism already correctly informing end users of when some type hinting would be needed.

## How to QA

* Add the following namespace under Eastwood (and this branch):

```clj
(ns eastwood.foo
  (:import
   (java.nio.file Files OpenOption Path)))

(defn do-something [path x]
  ;; ...
  (Files/write path (byte-array 10) (into-array OpenOption []))
  ;; ...
  true)
```

* Run the following command:
  * `lein eastwood "{:namespaces [eastwood.foo]}"`

* Note how no noisy outout is printed

* Note how the command correctly reports 0 exceptions, 0 warnings