### PR TITLE
Fix unintentional Clojure 1.10+ requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,6 @@ commands:
           name: Run tests with all supported clojure versions
           command: |
             lein test-all
-      - run:
-          name: Lint with all supported clojure versions
-          command: |
-            lein eastwood-all
 
 jobs:
 

--- a/project.clj
+++ b/project.clj
@@ -41,10 +41,10 @@
              :1.10.1 {:dependencies [[org.clojure/clojure "1.10.1"]]}
              :1.10.2 {:dependencies [[org.clojure/clojure "1.10.2"]]}}
   :aliases {"test-all" ["with-profile"
-                        "1.7:dev,test,1.8:dev,test,1.9:dev,test,1.10.1:dev,test,1.10.2"
+                        "dev,test,1.7:dev,test,1.8:dev,test,1.9:dev,test,1.10.1:dev,test,1.10.2"
                         "test"]
             "lint-all" ["with-profile"
-                        "1.7:dev,test,1.8:dev,test,1.9:dev,test,1.10.1:dev,test,1.10.2"
+                        "dev,test,1.7:dev,test,1.8:dev,test,1.9:dev,test,1.10.1:dev,test,1.10.2"
                         "eastwood-all"]}
   :eastwood {:source-paths ["src"]
              :test-paths ["test"]

--- a/src/eastwood/linters/implicit_dependencies.clj
+++ b/src/eastwood/linters/implicit_dependencies.clj
@@ -5,7 +5,11 @@
 
 
 (defn var->ns-symbol [var]
-  (symbol (namespace (symbol var))))
+  (if (util/clojure-1-10-or-later)
+    ;; Use the most accurate method:
+    (symbol (namespace (symbol var)))
+    (let [^clojure.lang.Namespace ns (-> var meta :ns)]
+      (.-name ns))))
 
 
 (defn within-other-ns-macro?

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -38,6 +38,9 @@ return value followed by the time it took to evaluate in millisec."
 (defn clojure-1-9-or-later []
   (min-clojure-version [1 9]))
 
+(defn clojure-1-10-or-later []
+  (min-clojure-version [1 10]))
+
 ;; Before Clojure 1.8.0, an :op :def node resulting from a defn form would
 ;; have its :init value equal to an AST node with :op :fn
 

--- a/test/eastwood/test/implicit_dependencies_linter_test.clj
+++ b/test/eastwood/test/implicit_dependencies_linter_test.clj
@@ -1,5 +1,6 @@
 (ns eastwood.test.implicit-dependencies-linter-test
   (:require [clojure.test :refer :all]
+            [eastwood.util :as util]
             [eastwood.test.linters-test :as linters-test]))
 
 (deftest implicit-dependency-linter
@@ -14,8 +15,9 @@
      :line 4,
      :column 3}
     1})
-  (linters-test/lint-test
-   'testcases.f08
-   [:implicit-dependencies]
-   {}
-   {}))
+  (when (util/clojure-1-10-or-later)
+    (linters-test/lint-test
+     'testcases.f08
+     [:implicit-dependencies]
+     {}
+     {})))


### PR DESCRIPTION
Fixes https://github.com/jonase/eastwood/issues/356

## How to QA

* temporarily change `:eval-in-leiningen true` to `false` (so that one doesn't use whatever Clojure version one's Lein is using)
* Run/observe these commands:

```shell
$ lein with-profile +1.9 test :only eastwood.test.implicit-dependencies-linter-test

Testing eastwood.test.implicit-dependencies-linter-test

Ran 1 tests containing 1 assertions.
0 failures, 0 errors.
$ lein with-profile +1.10 test :only eastwood.test.implicit-dependencies-linter-test

Testing eastwood.test.implicit-dependencies-linter-test

Ran 1 tests containing 2 assertions.
0 failures, 0 errors.
```

* Note how a 1 fewer assertion is run in the `+1.9` case.