### PR TITLE
`analyze+eval`: fall back to evaluating a form with less metadata

### DIFF
--- a/cases/testcases/large_defprotocol.clj
+++ b/cases/testcases/large_defprotocol.clj
@@ -1,0 +1,32 @@
+(ns testcases.large-defprotocol)
+
+(defprotocol Foo
+  "Exercises https://github.com/jonase/eastwood/issues/191"
+  
+  (aa [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ab [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ac [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ad [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ae [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (af [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ag [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ah [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ai [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (aj [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ak [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (al [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (am [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (an [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ao [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ap [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (aq [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ar [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (as [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (at [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (au [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (av [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (aw [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ax [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (ay [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl])
+  (az [_ aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl aasdl]
+    "dfskasfdasfdf adfkj adfskjadfs lkjdaf lkjadf lkadjsf aldkfj aldsfkj adlskfj aldkfja"))

--- a/copied-deps/eastwood/copieddeps/dep2/clojure/tools/analyzer/jvm.clj
+++ b/copied-deps/eastwood/copieddeps/dep2/clojure/tools/analyzer/jvm.clj
@@ -583,6 +583,8 @@
               :raw-forms  raw-forms})
            (let [a (analyze mform env opts)
                  frm (emit-form a)
+                 ;; NOTE: the retry inside the `catch` is a monkeypatch from Eastwood side.
+                 ;; ------------ begin patch -------------
                  result (try
                           ;; eval the emitted form rather than directly the form to avoid double macroexpansion:
                           (eval frm)
@@ -599,7 +601,9 @@
                                      
                                      eval)
                                 (catch Exception e
-                                  (handle-evaluation-exception (ExceptionThrown. e a)))))))]
+                                  (handle-evaluation-exception (ExceptionThrown. e a)))))))
+                 ;; ------------ end patch -------------
+                 ]
              (merge a {:result    result
                        :raw-forms raw-forms})))))))
 

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -94,3 +94,8 @@
       invalid-namespaces true  false
       valid-namespaces   true  true
       valid-namespaces   false true)))
+
+(deftest large-defprotocol-test
+  (testing "A large defprotocol doesn't cause a 'Method code too large' exception"
+    (is (= {:some-warnings false}
+           (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.large-defprotocol}))))))


### PR DESCRIPTION
This metadata, likely provenant from Eastwood's processing, was bloating code size, leading to "Method code too large!" exceptions.

...Metadata is only removed as a last resource. I also checked that basically all of the proposed metadata (`:arglists :file :line :column :end-line :end-column`) has to be removed and not just a subset. I guess every byte counts!

Fixes https://github.com/jonase/eastwood/issues/191
Fixes https://github.com/jonase/eastwood/issues/344