### PR TITLE
Implement `:ignored-faults` configuration  option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2346,6 +2346,28 @@ remains the same throughout the file.  This is a common convention
 followed by most Clojure source code, and required by several other
 Clojure development tools.
 
+## Ignored faults
+
+If there are specific instances of linter faults that you need to supress
+(e.g. for making a CI build pass), you can use the `:ignored-faults` option.
+
+It has the following shape:
+
+```clj
+;;linter-name            ns-name            target
+;;---                    ---                ---
+{:implicit-dependencies {'example.namespace {:line 3 :column 2}} 
+ :unused-ret-vals       {'another.namespace true}}
+```
+
+`{:line 3 :column 2}` matches a given linter (within a specific ns)
+if and only if the linter triggers that fault in that exact line/column.
+Accordingly, you might have to update the configured line/column from time to time.
+
+If you wish to ban a ignore a linter for an entire namespace, pass `true` instead, as shown in the example above.
+
+> Please, if encountering an issue in Eastwood, consider reporting it in addition to (or instead of) silencing it.
+> This way Eastwood can continue to be a precise linter, having as few false positives as possible.
 
 ## Change log
 

--- a/README.md
+++ b/README.md
@@ -2354,17 +2354,30 @@ If there are specific instances of linter faults that you need to supress
 It has the following shape:
 
 ```clj
-;;linter-name            ns-name            target
-;;---                    ---                ---
-{:implicit-dependencies {'example.namespace {:line 3 :column 2}} 
- :unused-ret-vals       {'another.namespace true}}
+;;linter-name            ns-name                target
+;;---                    ---                    ---
+{:implicit-dependencies {'example.namespace     [{:line 3 :column 2}]
+                         'another.namespace     [{:line 79}]
+                         'random.namespace      [{:line 89}, {:line 110}, {:line 543 :column 10}]} 
+ :unused-ret-vals       {'yet.another.namespace true}}
 ```
 
-`{:line 3 :column 2}` matches a given linter (within a specific ns)
-if and only if the linter triggers that fault in that exact line/column.
-Accordingly, you might have to update the configured line/column from time to time.
+An entry like `:implicit-dependencies {'example.namespace [{:line 3 :column 2}]` has the meaning
+"the linter `:implicit-dependencies` should be ignored in line 3, column 2".
 
-If you wish to ban a ignore a linter for an entire namespace, pass `true` instead, as shown in the example above.
+Note that the `target`s are expressed as vectors, since there may be multiple instances to ignore.
+
+The following are acceptable `target`s:
+
+* `[{:line 1 :column 1}]`
+  * will only ignore a linter if line _and_ column do match
+* `[{:line 1}]`
+  * will match line, disregarding the column
+  * it's a bit more lenient than the previous syntax, while not too much
+* `true`
+  * will match any ocurrence within the given namespace, regardless of line/column
+  * this is the most lenient choce, which of course can create some false negatives.
+  * if passing `true`, you don't need to wrap it in a vector.
 
 > Please, if encountering an issue in Eastwood, consider reporting it in addition to (or instead of) silencing it.
 > This way Eastwood can continue to be a precise linter, having as few false positives as possible.

--- a/cases/testcases/ignored_faults_example.clj
+++ b/cases/testcases/ignored_faults_example.clj
@@ -1,0 +1,4 @@
+(ns testcases.ignored-faults-example
+  "A sample namespace for the 'ignored-faults' feature")
+
+clojure.set/difference

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,19 @@
 # Change log for Eastwood
 
-## Changes from 0.3.13 to 
+## Changes from 0.3.14 to 0.4.0 
+
+* Introduce `:ignored-faults` option
+   * See: https://github.com/jonase/eastwood#ignored-faults
+   * Fixes https://github.com/jonase/eastwood/issues/21
+* Support require+import pattern for defrecords, without triggering "Namespace is never used"
+   * Fixes https://github.com/jonase/eastwood/issues/210
+* Remove a noisy println, on certain cases that would be already caught by the reflection warnings mechanism.
+   * Fixes https://github.com/jonase/eastwood/issues/355
+* Restore accidentally-dropped support for Clojure < 1.10
+   * Fixes https://github.com/jonase/eastwood/issues/356
+* Drop support for Clojure 1.6
+
+## Changes from 0.3.13 to 0.3.14 
 
 * Improve `:implicit-dependencies` to support potemkin/import-vars
 

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -1,13 +1,12 @@
 (ns eastwood.lint-test
   (:use [clojure.test ])
-  (:require [eastwood.lint :refer :all]
+  (:require [eastwood.lint :as sut :refer :all]
             [eastwood.copieddeps.dep11.clojure.java.classpath :as classpath]
             [eastwood.util :as util]
             [eastwood.copieddeps.dep9.clojure.tools.namespace.dir :as dir]
             [eastwood.copieddeps.dep9.clojure.tools.namespace.track :as track]
             [eastwood.reporting-callbacks :as reporting])
   (:import java.io.File))
-
 
 (deftest expand-ns-keywords-test
   (testing ""
@@ -99,3 +98,36 @@
   (testing "A large defprotocol doesn't cause a 'Method code too large' exception"
     (is (= {:some-warnings false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.large-defprotocol}))))))
+
+(deftest ignore-fault?-test
+  (are [input expected] (= expected
+                           (sut/ignore-fault? input
+                                              {:warn-data {:namespace-sym 'some-ns
+                                                           :line 1
+                                                           :column 2
+                                                           :linter :some-linter}}))
+    nil                                                  false
+    {}                                                   false
+    {:some-linter {'some-ns true}}                       true
+    {:different-linter {'some-ns true}}                  false
+    {:some-linter {'different-ns true}}                  false
+    {:some-linter {'some-ns {:line 1 :column 2}}}        true
+    {:some-linter {'some-ns {:line 999 :column 2}}}      false
+    {:some-linter {'some-ns {:line 1 :column 999}}}      false
+    {:some-linter {'different-ns {:line 1 :column 2}}}   false
+    {:some-linter {'different-ns {:line 999 :column 2}}} false
+    {:some-linter {'different-ns {:line 1 :column 999}}} false))
+
+(deftest ignored-faults-test
+  (testing "A ignored-faults can remove warnings.
+The ignored-faults must match ns (exactly) and file/column (exactly, but only if provided)"
+    (are [input expected] (= expected
+                             (-> eastwood.lint/default-opts
+                                 (assoc :namespaces #{'testcases.ignored-faults-example}
+                                        :ignored-faults input)
+                                 (eastwood.lint/eastwood)))
+      {}                                                                                {:some-warnings true}
+      {:implicit-dependencies {'testcases.ignored-faults-example true}}                 {:some-warnings false}
+      {:implicit-dependencies {'testcases.ignored-faults-example {:line 4 :column 1}}}  {:some-warnings false}
+      {:implicit-dependencies {'testcases.ignored-faults-example {:line 4 :column 99}}} {:some-warnings true}
+      {:implicit-dependencies {'testcases.ignored-faults-example {:line 99 :column 1}}} {:some-warnings true})))

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -106,17 +106,42 @@
                                                            :line 1
                                                            :column 2
                                                            :linter :some-linter}}))
-    nil                                                  false
-    {}                                                   false
-    {:some-linter {'some-ns true}}                       true
-    {:different-linter {'some-ns true}}                  false
-    {:some-linter {'different-ns true}}                  false
-    {:some-linter {'some-ns {:line 1 :column 2}}}        true
-    {:some-linter {'some-ns {:line 999 :column 2}}}      false
-    {:some-linter {'some-ns {:line 1 :column 999}}}      false
-    {:some-linter {'different-ns {:line 1 :column 2}}}   false
-    {:some-linter {'different-ns {:line 999 :column 2}}} false
-    {:some-linter {'different-ns {:line 1 :column 999}}} false))
+    nil                                                                        false
+    {}                                                                         false
+    {:some-linter {'some-ns true}}                                             true
+    {:some-linter {'some-ns [true]}}                                           true
+    {:different-linter {'some-ns true}}                                        false
+    {:different-linter {'some-ns [true]}}                                      false
+    {:some-linter {'different-ns true}}                                        false
+    {:some-linter {'different-ns [true]}}                                      false
+    {:some-linter {'some-ns {:line 1 :column 2}}}                              true
+    {:some-linter {'some-ns [{:line 1 :column 2}]}}                            true
+    {:some-linter {'some-ns {:line 999 :column 2}}}                            false
+    {:some-linter {'some-ns [{:line 999 :column 2}]}}                          false
+    {:some-linter {'some-ns {:line 1 :column 999}}}                            false
+    {:some-linter {'some-ns [{:line 1 :column 999}]}}                          false
+    {:some-linter {'some-ns [{:line 1 :column 2} {:line 1 :column 999}]}}      true
+    {:some-linter {'some-ns [{:line 1 :column 999} {:line 1 :column 2}]}}      true
+    {:some-linter {'different-ns {:line 1 :column 2}}}                         false
+    {:some-linter {'different-ns [{:line 1 :column 2}]}}                       false
+    {:some-linter {'different-ns {:line 999 :column 2}}}                       false
+    {:some-linter {'different-ns [{:line 999 :column 2}]}}                     false
+    {:some-linter {'different-ns {:line 1 :column 999}}}                       false
+    {:some-linter {'different-ns [{:line 1 :column 999}]}}                     false
+    {:some-linter {'different-ns [{:line 1 :column 2} {:line 1 :column 999}]}} false
+    ;; Exercises line-only matching:
+    {:some-linter {'some-ns {:line 1}}}                                        true
+    {:some-linter {'some-ns [{:line 1}]}}                                      true
+    {:some-linter {'some-ns {:line 999}}}                                      false
+    {:some-linter {'some-ns [{:line 999}]}}                                    false
+    {:some-linter {'some-ns [{:line 1} {:line 1}]}}                            true
+    {:some-linter {'some-ns [{:line 1} {:line 2}]}}                            true
+    {:some-linter {'some-ns [{:line 2} {:line 1} {:line 2}]}}                  true
+    {:some-linter {'different-ns {:line 1}}}                                   false
+    {:some-linter {'different-ns [{:line 1}]}}                                 false
+    {:some-linter {'different-ns {:line 999}}}                                 false
+    {:some-linter {'different-ns [{:line 999}]}}                               false
+    {:some-linter {'different-ns [{:line 1} {:line 1}]}}                       false))
 
 (deftest ignored-faults-test
   (testing "A ignored-faults can remove warnings.
@@ -128,6 +153,6 @@ The ignored-faults must match ns (exactly) and file/column (exactly, but only if
                                  (eastwood.lint/eastwood)))
       {}                                                                                {:some-warnings true}
       {:implicit-dependencies {'testcases.ignored-faults-example true}}                 {:some-warnings false}
-      {:implicit-dependencies {'testcases.ignored-faults-example {:line 4 :column 1}}}  {:some-warnings false}
-      {:implicit-dependencies {'testcases.ignored-faults-example {:line 4 :column 99}}} {:some-warnings true}
-      {:implicit-dependencies {'testcases.ignored-faults-example {:line 99 :column 1}}} {:some-warnings true})))
+      {:implicit-dependencies {'testcases.ignored-faults-example [{:line 4 :column 1}]}}  {:some-warnings false}
+      {:implicit-dependencies {'testcases.ignored-faults-example [{:line 4 :column 99}]}} {:some-warnings true}
+      {:implicit-dependencies {'testcases.ignored-faults-example [{:line 99 :column 1}]}} {:some-warnings true})))


### PR DESCRIPTION
Fixes #21
Closes https://github.com/jonase/eastwood/issues/187
Closes https://github.com/jonase/eastwood/issues/282
Closes https://github.com/jonase/eastwood/issues/165

The way I approached this fix was simple: making the 'ignoring' a property of the output (our emitted reports), not of the input (Clojure code).

Accordingly, end users don't have to add extraneous metadata/comments (which meaning can be unclear to newcomers, and importantly to other tooling, which might interpret it badly, clean it up, etc).

It isn't necessarily the last word on the topic of course, but this approach seems simple and non-invasive (vs. altering Clojure source code, and very plausibly our whole analysis/linting pipeline).

Importantly, as I view it it makes Eastwood a more viable tool for being run as a hard check on CI environments.

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [x] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
