### PR TITLE
Strengthen `suspicious-is-forms`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2361,7 +2361,7 @@ more likely to run across new undiscovered bugs), install Eastwood in
 your local Maven repository:
 
     $ cd path/to/eastwood
-    $ lein install
+    $ lein with-profile +eastwood-plugin install
 
 Then add `[jonase/eastwood "0.2.8"]` (or whatever is the
 current version number in the defproject line of `project.clj`) to

--- a/doc/README.next.md
+++ b/doc/README.next.md
@@ -2296,7 +2296,7 @@ more likely to run across new undiscovered bugs), install Eastwood in
 your local Maven repository:
 
     $ cd path/to/eastwood
-    $ lein install
+    $ lein with-profile +eastwood-plugin install
 
 Then add `[jonase/eastwood "0.2.6-SNAPSHOT"]` (or whatever is the
 current version number in the defproject line of `project.clj`) to


### PR DESCRIPTION
Fixes https://github.com/jonase/eastwood/issues/298
Closes https://github.com/jonase/eastwood/issues/306

Sadly, while I could reproduce the bug when checking cider-nrepl as a whole, I couldn't when extracting only the `cider.nrepl.middleware.stacktrace-spec-test` ns.

So I'm not sure we should bother growing the test suite.

I did add some strategic `assert`s, which of course are, in a way, 'inline tests' preventing a regression.

## How to QA

#### Verify the bug can be reproduced

```
rm -rf ~/.m2/repository/jonase/
cd
git clone https://github.com/clojure-emacs/cider-nrepl xxx
cd xxx
git checkout b2c0b920d762fdac2f8210805df2055af63f2eb1
# erase cache:
# rm -rf .eastwood
lein with-profile +1.9 eastwood '{:exclude-namespaces [cider-nrepl.plugin cider.nrepl.test-session]}'
# ^ should complain about `:invoke`
```

#### Install `Eastwood @ master` and verify it's gone

```
cd <your Eastwood clone>
lein with-profile +eastwood-plugin install
# go to the cider-nrepl clone, make sure to bump the Eastwood plugin within its project.clj
# erase cache:
# rm -rf .eastwood
lein with-profile +1.9 eastwood '{:exclude-namespaces [cider-nrepl.plugin cider.nrepl.test-session]}'
# ^ should not complain about `:invoke`!
```