### PR TITLE
[Fix #341] Remove `^:const` metadata prior to processing a given form

### DIFF
--- a/cases/testcases/const.clj
+++ b/cases/testcases/const.clj
@@ -1,0 +1,16 @@
+(ns testcases.const
+  "Exercises https://github.com/jonase/eastwood/issues/341")
+
+;; Makes this test case more deterministic when re-running the associated `deftest` from a repl:
+(ns-unmap (-> ::_ namespace symbol the-ns)
+          'balanced?)
+
+(defn ^:const balanced?
+  "Returns whether brackets contained in expr are balanced"
+  ([expr] (balanced? expr 0))
+  ([[x & xs] count]
+   (cond (neg? count) false
+         (nil? x) (zero? count)
+         (= x \[) (recur xs (inc count))
+         (= x \]) (recur xs (dec count))
+         :else (recur xs count))))

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,12 @@
 
 ## Changes from 0.3.14 to 0.4.0 
 
+* Improve compatibility with forms defined with `^:const` 
+  * Fixes https://github.com/jonase/eastwood/issues/341
+* Improve compatibility with CIDER
+  * Fixes https://github.com/jonase/eastwood/issues/298
+* Improve compatibility with large defprotocols
+  * Fixes https://github.com/jonase/eastwood/issues/191
 * Introduce `:ignored-faults` option
    * See: https://github.com/jonase/eastwood#ignored-faults
    * Fixes https://github.com/jonase/eastwood/issues/21

--- a/test/eastwood/analyze_ns_test.clj
+++ b/test/eastwood/analyze_ns_test.clj
@@ -1,0 +1,15 @@
+(ns eastwood.analyze-ns-test
+  (:require
+   [clojure.test :refer [are deftest is testing]]
+   [eastwood.analyze-ns :as sut]))
+
+(deftest cleanup
+  (testing "Removes `:const` metadata"
+    (are [f input expected] (let [result (f input)]
+                              (is (= result input)
+                                  "Applying `f` should return an equivalent object (even after removing metadata)")
+                              (= expected
+                                 (-> result second meta :const)))
+      identity    '(defn ^:const foo) true
+      sut/cleanup '(defn ^:const foo) nil
+      sut/cleanup '(defn foo)         nil)))

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -156,3 +156,8 @@ The ignored-faults must match ns (exactly) and file/column (exactly, but only if
       {:implicit-dependencies {'testcases.ignored-faults-example [{:line 4 :column 1}]}}  {:some-warnings false}
       {:implicit-dependencies {'testcases.ignored-faults-example [{:line 4 :column 99}]}} {:some-warnings true}
       {:implicit-dependencies {'testcases.ignored-faults-example [{:line 99 :column 1}]}} {:some-warnings true})))
+
+(deftest const-handling
+  (testing "Processing a namespace where `^:const` is used results in no exceptions being thrown"
+    (is (= {:some-warnings false}
+           (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.const}))))))


### PR DESCRIPTION
`^:const` is not part of any public API described in https://github.com/clojure/clojure-site.

However usage of it can be still found in the wild, perhaps influenced by past knowledge.

https://github.com/jonase/eastwood/issues/341 showed that attempting to process a defn having `^:const` would throw an exception.
This commit proposes removing that piece of metadata, since it doesn't alter semantics and saves the effort of investigating a more intrincate integration with tools.analyzer (for what I believe is not a public API anyway).

It's worth noting that https://clojure.org/reference/compilation#directlinking **is** a public API,
and something that can be used in production environments instead of `^:const`, without fearing a clash with Eastwood whatsoever.

Fixes https://github.com/jonase/eastwood/issues/341

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
