### PR TITLE
[Fix #244] Use `leininen.core.main/exit` when suitable

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,8 @@
 
 ## Changes from 0.3.14 to 0.4.0 
 
+* Improve compatibility with Leiningen higher-order tasks, plugins, etc
+  * Fixes https://github.com/jonase/eastwood/issues/244
 * Improve compatibility with forms defined with `^:const` 
   * Fixes https://github.com/jonase/eastwood/issues/341
 * Improve compatibility with CIDER

--- a/src/eastwood/exit.clj
+++ b/src/eastwood/exit.clj
@@ -1,0 +1,10 @@
+(ns eastwood.exit)
+;; This is a dedicated ns because `eastwood.versioncheck` performs `(require 'eastwood.lint)` carefully.
+;; We want to provide the `exit-fn` without providing more defns unawarely.
+
+;; This is a defn because the result of `find-ns` can change over time
+(defn exit-fn []
+  (if (find-ns 'leiningen.core.main)
+    @(resolve 'leiningen.core.main/exit)
+    (fn [n]
+      (System/exit n))))

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -11,6 +11,7 @@
             [eastwood.copieddeps.dep9.clojure.tools.namespace.find :as find]
             [eastwood.copieddeps.dep9.clojure.tools.namespace.track :as track]
             [eastwood.error-messages :as msgs]
+            [eastwood.exit :refer [exit-fn]]
             [eastwood.linters.deprecated :as deprecated]
             [eastwood.linters.implicit-dependencies :as implicit-dependencies]
             [eastwood.linters.misc :as misc]
@@ -567,7 +568,7 @@ Return value:
       ;; Exit with non-0 exit status for the benefit of any shell
       ;; scripts invoking Eastwood that want to know if there were no
       ;; errors, warnings, or exceptions.
-      (System/exit 1)
+      ((exit-fn) 1)
       ;; Eastwood does not use future, pmap, or clojure.shell/sh now
       ;; (at least not yet), but it may evaluate code that does when
       ;; linting a project.  Call shutdown-agents to avoid the

--- a/src/eastwood/versioncheck.clj
+++ b/src/eastwood/versioncheck.clj
@@ -1,4 +1,6 @@
-(ns eastwood.versioncheck)
+(ns eastwood.versioncheck
+  (:require
+   [eastwood.exit :refer [exit-fn]]))
 
 (def main
   (delay
@@ -8,8 +10,8 @@
 
 (defn run-eastwood [opts]
   (let [{:keys [major minor]} *clojure-version*]
-    (when-not (>= (compare [major minor] [1 5]) 0)
-      (println "Eastwood requires Clojure version >= 1.5.0.  This project uses version"
+    (when-not (>= (compare [major minor] [1 7]) 0)
+      (println "Eastwood requires Clojure version >= 1.7.0.  This project uses version"
                (clojure-version))
-      (System/exit 1)))
+      ((exit-fn) 1)))
   (@main opts))


### PR DESCRIPTION
Lein's `exit` results in more graceful exit program termination when using Eastwood as part of another plugin, higher-order task, etc.

Fixes https://github.com/jonase/eastwood/issues/244

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
