### PR TITLE
[Fix #339] Upgrade `linter-executor-atom` to `pmap`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 
 executor_defaults: &executor_defaults
+  # 2xlarge: use as many CPU cores as possible, to exercise parallelism as realistically as possible
+  # 2xlarge is only applied in paid accounts and gracefully degrades to a compatible resource_class in regular accounts
+  resource_class: 2xlarge
   working_directory: ~/repo
 
 executors:

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ Currently only a `:naive` form of parallelism is supported, which just uses
 `pmap` to run the linters over your namespaces. You can specify
 `:parallelism?` in your options map, currently `:none` and `:naive` are valid options.
 
+> :parallelism? performs AST analysis/evaluation in parallel and might cause issues.
+
 ## Only lint files modified since last run
 
 As of version 0.3.5, you can now instruct eastwood to only lint the files

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,9 @@
 
 ## Changes from 0.3.14 to 0.4.0 
 
+* Default to linter parallelism
+  * Linter parallelism (as opposed to the `:parallelism?` option, which affects analysis/evaluation) is thread-safe.
+  * Fixes https://github.com/jonase/eastwood/issues/339
 * Improve compatibility with Leiningen higher-order tasks, plugins, etc
   * Fixes https://github.com/jonase/eastwood/issues/244
 * Improve compatibility with forms defined with `^:const` 

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -889,7 +889,7 @@ StringWriter."
   "A `#'map`-like function that will run each of the linters.
 
   Can be customized in order to achieve linter parallelism, or extra logging, etc."
-  (atom map))
+  (atom pmap))
 
 (defn set-linter-executor! [executor]
   (reset! linter-executor-atom executor))
@@ -922,7 +922,7 @@ StringWriter."
                                       builtin-config-files)
                                  config-files)]
     (reset! warning-enable-config-atom [])
-    (reset! linter-executor-atom map)
+    (reset! linter-executor-atom pmap)
     (doseq [config-file all-config-files]
       (when (debug? :config opt)
         (println (format "Loading config file: %s" config-file)))


### PR DESCRIPTION
 I've used `pmap` over the last 12 months, continuously (in CI and repls alike, across work/personal projects) observing no issues.

So it seems a safe and convenient default to improve.

`clojure.core/pmap` is not too bad of a choice (vs. other pmap-like functions) because its implementation caps the maximum amount of spawned threads to a number relative to CPU count.

So the workloads, which are CPU-bound, will be treated as such, without possibly hogging the OS with an excess of threads.

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [x] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
