### PR TITLE
Prettify changelog for 0.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 executor_defaults: &executor_defaults
-  # 2xlarge: use as many CPU cores as possible, to exercise parallelism as realistically as possible
-  # 2xlarge is only applied in paid accounts and gracefully degrades to a compatible resource_class in regular accounts
-  resource_class: 2xlarge
+  # xlarge: use as many CPU cores as possible, to exercise parallelism as realistically as possible
+  # xlarge is only applied in paid accounts and gracefully degrades to a compatible resource_class in regular accounts
+  resource_class: xlarge
   working_directory: ~/repo
 
 executors:

--- a/README.md
+++ b/README.md
@@ -2408,7 +2408,7 @@ your `:plugins` vector in your `:user` profile, perhaps in your
 
 ## License
 
-Copyright (C) 2012-2015 Jonas Enlund, Nicola Mometto, and Andy Fingerhut
+Copyright (C) 2012-2021 Jonas Enlund, Nicola Mometto, and Andy Fingerhut
 
 Distributed under the Eclipse Public License, the same as Clojure.
 

--- a/changes.md
+++ b/changes.md
@@ -2,9 +2,17 @@
 
 ## Changes from 0.3.14 to 0.4.0 
 
+#### New
+
+* Introduce `:ignored-faults` option
+   * See: https://github.com/jonase/eastwood#ignored-faults
+   * Fixes https://github.com/jonase/eastwood/issues/21
 * Default to linter parallelism
   * Linter parallelism (as opposed to the `:parallelism?` option, which affects analysis/evaluation) is thread-safe.
   * Fixes https://github.com/jonase/eastwood/issues/339
+
+#### Bugfixes
+
 * Improve compatibility with Leiningen higher-order tasks, plugins, etc
   * Fixes https://github.com/jonase/eastwood/issues/244
 * Improve compatibility with forms defined with `^:const` 
@@ -13,15 +21,15 @@
   * Fixes https://github.com/jonase/eastwood/issues/298
 * Improve compatibility with large defprotocols
   * Fixes https://github.com/jonase/eastwood/issues/191
-* Introduce `:ignored-faults` option
-   * See: https://github.com/jonase/eastwood#ignored-faults
-   * Fixes https://github.com/jonase/eastwood/issues/21
 * Support require+import pattern for defrecords, without triggering "Namespace is never used"
    * Fixes https://github.com/jonase/eastwood/issues/210
 * Remove a noisy println, on certain cases that would be already caught by the reflection warnings mechanism.
    * Fixes https://github.com/jonase/eastwood/issues/355
 * Restore accidentally-dropped support for Clojure < 1.10
    * Fixes https://github.com/jonase/eastwood/issues/356
+
+#### Breaking changes
+
 * Drop support for Clojure 1.6
 
 ## Changes from 0.3.13 to 0.3.14 


### PR DESCRIPTION
Makes it more comprehensible as it's a big release

Also downgraded the builds to xlarge (for those running Eastwood CI with a paid account) since 2xlarge is reserved for larger customers