### PR TITLE
Formatting

### DIFF
--- a/lein-eastwood/leiningen/eastwood.clj
+++ b/lein-eastwood/leiningen/eastwood.clj
@@ -1,8 +1,9 @@
 (ns leiningen.eastwood
-  (:require [clojure.pprint :as pp]
-            [leiningen.core.eval :as leval]
-            [leiningen.core.main :as lein]
-            [eastwood.version :as version]))
+  (:require
+   [clojure.pprint :as pp]
+   [eastwood.version :as version]
+   [leiningen.core.eval :as eval]
+   [leiningen.core.main :as main]))
 
 ;; 'lein help' prints only the first line of the string returned by
 ;; help.  'lein help eastwood' prints all of it, plus the arg vectors
@@ -28,7 +29,6 @@ your :source-paths, use this command:
 For other options, see the full documentation on-line here:
 
     https://github.com/jonase/eastwood")))
-
 
 ;; Everything from here down to, and including, pprint-meta is a copy
 ;; of some functions from namespace eastwood.util, specifically to
@@ -69,8 +69,8 @@ http://dev.clojure.org/jira/browse/CLJ-1445"
         (fn pm [o]
           (let [o (if (protocol? o)
                     (assoc o
-                      :var :true-value-replaced-to-avoid-pprint-infinite-loop
-                      :method-builders :true-value-replaced-to-avoid-pprint-infinite-loop)
+                           :var :true-value-replaced-to-avoid-pprint-infinite-loop
+                           :method-builders :true-value-replaced-to-avoid-pprint-infinite-loop)
                     o)]
             (when (meta o)
               (print "^")
@@ -110,12 +110,12 @@ http://dev.clojure.org/jira/browse/CLJ-1445"
   ([project] (eastwood project "{}"))
   ([project opts]
    (cond
-     (= opts "help") (lein/info (help))
+     (= opts "help") (main/info (help))
      (= opts "lein-project")
      (do
-       (lein/info (with-out-str (pprint-meta (into (sorted-map) project))))
-       (lein/info "\nValue of :eastwood key in project map:")
-       (lein/info (with-out-str (pprint-meta (into (sorted-map) (:eastwood project))))))
+       (main/info (with-out-str (pprint-meta (into (sorted-map) project))))
+       (main/info "\nValue of :eastwood key in project map:")
+       (main/info (with-out-str (pprint-meta (into (sorted-map) (:eastwood project))))))
 
      :else
      (let [leiningen-paths (select-keys project [:source-paths
@@ -123,18 +123,18 @@ http://dev.clojure.org/jira/browse/CLJ-1445"
            leiningen-opts (:eastwood project)
            cmdline-opts (read-string opts)
            opts (merge leiningen-paths leiningen-opts cmdline-opts)]
-       (lein/debug "\nLeiningen paths:")
-       (lein/debug (with-out-str (pprint-meta (into (sorted-map) leiningen-paths))))
-       (lein/debug "\nLeiningen options map:")
-       (lein/debug (with-out-str (pprint-meta (into (sorted-map) leiningen-opts))))
-       (lein/debug "\nCommand line options map:")
-       (lein/debug (with-out-str (pprint-meta (into (sorted-map) cmdline-opts))))
-       (lein/debug "\nMerged options map:")
-       (lein/debug (with-out-str (pprint-meta (into (sorted-map) opts))))
-       (lein/debug "\nLeiningen project map:")
-       (lein/debug (with-out-str (pprint-meta (into (sorted-map) project))))
-       (lein/debug)
-       (leval/eval-in-project
+       (main/debug "\nLeiningen paths:")
+       (main/debug (with-out-str (pprint-meta (into (sorted-map) leiningen-paths))))
+       (main/debug "\nLeiningen options map:")
+       (main/debug (with-out-str (pprint-meta (into (sorted-map) leiningen-opts))))
+       (main/debug "\nCommand line options map:")
+       (main/debug (with-out-str (pprint-meta (into (sorted-map) cmdline-opts))))
+       (main/debug "\nMerged options map:")
+       (main/debug (with-out-str (pprint-meta (into (sorted-map) opts))))
+       (main/debug "\nLeiningen project map:")
+       (main/debug (with-out-str (pprint-meta (into (sorted-map) project))))
+       (main/debug)
+       (eval/eval-in-project
         (maybe-add-eastwood project)
         `(eastwood.versioncheck/run-eastwood '~opts)
         '(require 'eastwood.versioncheck))))))

--- a/src/eastwood/analyze_ns.clj
+++ b/src/eastwood/analyze_ns.clj
@@ -207,7 +207,7 @@ the value of File/separator for the platform."
       pass/add-ancestors))
 
 (defn wrapped-exception? [result]
-  (if (instance? eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm.ExceptionThrown result)
+  (when (instance? eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm.ExceptionThrown result)
     (.e ^eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm.ExceptionThrown result)))
 
 (defn asts-with-eval-exception

--- a/src/eastwood/analyze_ns.clj
+++ b/src/eastwood/analyze_ns.clj
@@ -1,25 +1,23 @@
 (ns eastwood.analyze-ns
   (:refer-clojure :exclude [macroexpand-1])
-  (:import (clojure.lang IMeta)
-           (java.net URL)
-           (java.io File))
-  (:require [clojure.string :as string]
-            [clojure.pprint :as pp]
-            [eastwood.util :as util]
-            [eastwood.passes :as pass]
-            [clojure.java.io :as io]
-            [eastwood.copieddeps.dep10.clojure.tools.reader :as tr]
-            [eastwood.copieddeps.dep10.clojure.tools.reader.reader-types :as rts]
-            [eastwood.copieddeps.dep9.clojure.tools.namespace.move :as move]
-            [eastwood.copieddeps.dep1.clojure.tools.analyzer
-             [ast :as ast]
-             [env :as env]
-             [passes :refer [schedule]]]
-            [eastwood.copieddeps.dep1.clojure.tools.analyzer.passes.trim :refer [trim]]
-            [eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as ana.jvm]
-            [eastwood.copieddeps.dep2.clojure.tools.analyzer.passes.jvm
-             [emit-form :refer [emit-form]]
-             [warn-on-reflection :refer [warn-on-reflection]]]))
+  (:require
+   [clojure.java.io :as io]
+   [clojure.pprint :as pp]
+   [clojure.string :as string]
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.env :as env]
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.passes :refer [schedule]]
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.passes.trim :refer [trim]]
+   [eastwood.copieddeps.dep10.clojure.tools.reader :as tr]
+   [eastwood.copieddeps.dep10.clojure.tools.reader.reader-types :as rts]
+   [eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as ana.jvm]
+   [eastwood.copieddeps.dep2.clojure.tools.analyzer.passes.jvm.emit-form :refer [emit-form]]
+   [eastwood.copieddeps.dep2.clojure.tools.analyzer.passes.jvm.warn-on-reflection :refer [warn-on-reflection]]
+   [eastwood.copieddeps.dep9.clojure.tools.namespace.move :as move]
+   [eastwood.passes :as pass]
+   [eastwood.util :as util])
+  (:import
+   (java.net URL)))
 
 ;; uri-for-ns, pb-reader-for-ns were copied from library
 ;; jvm.tools.analyzer, then later probably diverged from each other.
@@ -60,7 +58,7 @@ the value of File/separator for the platform."
 (defn gen-interface-form? [form]
   (and (seq? form)
        (contains? #{'gen-interface 'clojure.core/gen-interface}
-          (first form))))
+                  (first form))))
 
 ;; Avoid macroexpand'ing a gen-interface form more than once, since it
 ;; causes an exception to be thrown.
@@ -73,7 +71,7 @@ the value of File/separator for the platform."
           pprint? (util/debug? :forms-pprint opt)]
       (when (or print-normally? pprint?)
         (println (format "dbg pre-analyze #%d ns=%s (meta ns)=%s"
-                          (count asts) (str ns) (meta ns)))
+                         (count asts) (str ns) (meta ns)))
         (when pprint?
           (println "    form before macroexpand:")
           (pp/pprint form))
@@ -124,11 +122,11 @@ the value of File/separator for the platform."
   (when (util/debug? :ns opt)
     (let [show-ast? (util/debug? :ast opt)]
       (when (or show-ast? (util/debug? :progress opt))
-        (println(format "dbg anal'd %d ns=%s%s"
-                          (count asts) (str ns)
-                          (if show-ast? " ast=" ""))))
+        (println (format "dbg anal'd %d ns=%s%s"
+                         (count asts) (str ns)
+                         (if show-ast? " ast=" ""))))
       (when show-ast?
-         (util/pprint-ast-node ast))
+        (util/pprint-ast-node ast))
       ;; TBD: Change this to macroexpand form, at least if
       ;; dont-expand-twice? returns false.
       (when (util/debug? :compare-forms opt)
@@ -148,7 +146,7 @@ the value of File/separator for the platform."
 (defn eastwood-wrong-tag-handler [t ast]
   (let [tag (if (= t :name/tag)
               (-> ast :name meta :tag)
-            (get ast t))]
+              (get ast t))]
 ;;    (println (format "\nWrong tag: t=%s %s (%s) in %s"
 ;;                     t tag (class tag)
 ;;                     (:name ast)))
@@ -212,7 +210,6 @@ the value of File/separator for the platform."
   (if (instance? eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm.ExceptionThrown result)
     (.e ^eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm.ExceptionThrown result)))
 
-
 (defn asts-with-eval-exception
   "tools.analyzer.jvm/analyze+eval returns an AST with a :result key
 being a specific class of Exception object, if an exception occurred
@@ -224,7 +221,6 @@ recursing into ASTs with :op equal to :do"
   [ast]
   (filter #(wrapped-exception? (:result %))
           (ast/nodes ast)))
-
 
 (defn remaining-forms [pushback-reader forms]
   (let [eof (reify)

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -1,27 +1,29 @@
 (ns eastwood.lint
-  (:require [clojure.java.io :as io]
-            [clojure.pprint :as pp]
-            [clojure.set :as set]
-            [clojure.string :as str]
-            [clojure.edn :as edn]
-            [eastwood.analyze-ns :as analyze]
-            [eastwood.copieddeps.dep11.clojure.java.classpath :as classpath]
-            [eastwood.copieddeps.dep9.clojure.tools.namespace.dir :as dir]
-            [eastwood.copieddeps.dep9.clojure.tools.namespace.file :as file]
-            [eastwood.copieddeps.dep9.clojure.tools.namespace.find :as find]
-            [eastwood.copieddeps.dep9.clojure.tools.namespace.track :as track]
-            [eastwood.error-messages :as msgs]
-            [eastwood.exit :refer [exit-fn]]
-            [eastwood.linters.deprecated :as deprecated]
-            [eastwood.linters.implicit-dependencies :as implicit-dependencies]
-            [eastwood.linters.misc :as misc]
-            [eastwood.linters.typetags :as typetags]
-            [eastwood.linters.typos :as typos]
-            [eastwood.linters.unused :as unused]
-            [eastwood.reporting-callbacks :as reporting]
-            [eastwood.util :as util]
-            [eastwood.version :as version])
-  (:import java.io.File))
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.pprint :as pp]
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [eastwood.analyze-ns :as analyze]
+   [eastwood.copieddeps.dep11.clojure.java.classpath :as classpath]
+   [eastwood.copieddeps.dep9.clojure.tools.namespace.dir :as dir]
+   [eastwood.copieddeps.dep9.clojure.tools.namespace.file :as file]
+   [eastwood.copieddeps.dep9.clojure.tools.namespace.find :as find]
+   [eastwood.copieddeps.dep9.clojure.tools.namespace.track :as track]
+   [eastwood.error-messages :as msgs]
+   [eastwood.exit :refer [exit-fn]]
+   [eastwood.linters.deprecated :as deprecated]
+   [eastwood.linters.implicit-dependencies :as implicit-dependencies]
+   [eastwood.linters.misc :as misc]
+   [eastwood.linters.typetags :as typetags]
+   [eastwood.linters.typos :as typos]
+   [eastwood.linters.unused :as unused]
+   [eastwood.reporting-callbacks :as reporting]
+   [eastwood.util :as util]
+   [eastwood.version :as version])
+  (:import
+   (java.io File)))
 
 ;; Note: Linters below with nil for the value of the key :fn,
 ;; e.g. :no-ns-form-found, can be enabled/disabled from the opt map
@@ -31,8 +33,7 @@
 ;; namespace.
 
 (def linter-info
-  [
-   {:name :no-ns-form-found,          :enabled-by-default true,
+  [{:name :no-ns-form-found,          :enabled-by-default true,
     :url "https://github.com/jonase/eastwood#no-ns-form-found",
     :fn (constantly nil)}
    {:name :non-clojure-file,          :enabled-by-default false,
@@ -114,7 +115,6 @@
     :url nil,
     :fn implicit-dependencies/implicit-dependencies}])
 
-
 (def linter-name->info (into {} (for [{:keys [name] :as info} linter-info]
                                   [name info])))
 
@@ -132,7 +132,6 @@
     (merge
      {:namespace-sym ns-sym}
      (util/file-warn-info uri cwd-file))))
-
 
 (defn- handle-lint-result [linter ns-info {:keys [msg loc] :as result}]
   {:kind :lint-warning,
@@ -208,14 +207,12 @@
       (str/replace File/separator ".")
       symbol))
 
-
 (defn ns-to-filename-set [namespace extensions]
   (let [basename (-> namespace
                      str
                      (str/replace "-" "_")
                      (str/replace "." File/separator))]
     (set (map #(str basename %) extensions))))
-
 
 (defn filename-namespace-mismatches [dir-name-strs]
   (let [files-by-dir (into {} (for [dir-name-str dir-name-strs]
@@ -253,8 +250,7 @@
                     ;; Use empty tracker if dir-name-strs is empty.
                     ;; Calling dir/scan-all will use complete Java
                     ;; classpath if called with an empty sequence.
-                    tracker)
-          ]
+                    tracker)]
       {:dirs dir-name-strs
        :non-clojure-files (::dir/non-clojure-files tracker)
        :files (set (::dir/files tracker))
@@ -298,7 +294,7 @@
 ;; is given that cannot be found.
 
 (defn effective-namespaces [exclude-namespaces namespaces
-                          {:keys [source-paths test-paths]} modified-since]
+                            {:keys [source-paths test-paths]} modified-since]
   ;; If keyword :source-paths occurs in namespaces or
   ;; excluded-namespaces, replace it with all namespaces found in
   ;; the directories in (:source-paths opts), in an order that
@@ -350,11 +346,11 @@
                                                    excluded-linters)
                                         known-linters)]
     (when (and (seq unknown-linters)
-             (not disable-linter-name-checks))
+               (not disable-linter-name-checks))
       (throw (ex-info "unknown-linter"
-              {:err :unknown-linter,
-               :err-data {:unknown-linters unknown-linters
-                          :known-linters known-linters}})))
+                      {:err :unknown-linter,
+                       :err-data {:unknown-linters unknown-linters
+                                  :known-linters known-linters}})))
 
     (set/intersection linters-requested known-linters)))
 
@@ -367,7 +363,6 @@
          (map :uri-or-file-name)
          (str/join " ")
          (reporting/note reporter))))
-
 
 (defn- lint-namespace [reporter namespace linters opts]
   (try
@@ -382,7 +377,6 @@
     (catch RuntimeException e
       {:lint-runtime-exception [e]
        :namespace [namespace]})))
-
 
 (defn debug-namespaces-to-be-reported [reporter namespaces]
   (reporting/debug reporter :ns (format "Namespaces to be linted:"))
@@ -520,7 +514,7 @@ Return value:
    :error-count (+ (count (:lint-errors summary))
                    (count (:lint-runtime-exception summary))
                    (count (:analyzer-exception summary)))
-   :lint-time (apply + (mapcat vals(:lint-times summary)))
+   :lint-time (apply + (mapcat vals (:lint-times summary)))
    :analysis-time (apply + (:analysis-time summary))})
 
 (defn make-report [reporter start-time {:keys [warning-count error-count] :as result}]
@@ -642,7 +636,7 @@ Keys in a warning map:
                    modified-since
                    cwd] :as opts} (last-options-map-adjustments opts reporter)
            namespaces-info (effective-namespaces exclude-namespaces namespaces
-                                               (setup-lint-paths source-paths test-paths) modified-since)
+                                                 (setup-lint-paths source-paths test-paths) modified-since)
            linter-info (select-keys opts [:linters :exclude-linters :add-linters :disable-linter-name-checks])
            {:keys [error error-data
                    lint-warnings
@@ -676,8 +670,8 @@ clojure.inspector/inspect-tree on it.  Example in REPL:
   ([] (-main (pr-str default-opts)))
   ([& opts]
    (if (and
-         (= 1 (count opts))
-         (string? (first opts)))
+        (= 1 (count opts))
+        (string? (first opts)))
      (eastwood-from-cmdline (edn/read-string (first opts)))
      (let [parsed (->> opts (interpose " ") (apply str) edn/read-string)]
        (eastwood-from-cmdline parsed)))))

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -303,9 +303,9 @@
   ;; once for each of :source-paths and :test-paths, and only if
   ;; needed.
   (let [all-ns (concat namespaces exclude-namespaces)
-        sp (if (some #{:source-paths} all-ns)
+        sp (when (some #{:source-paths} all-ns)
              (nss-in-dirs source-paths modified-since))
-        tp (if (some #{:test-paths} all-ns)
+        tp (when (some #{:test-paths} all-ns)
              (nss-in-dirs test-paths modified-since))
         expanded-namespaces {:source-paths (:namespaces sp)
                              :test-paths (:namespaces tp)}

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -5,7 +5,7 @@
    [clojure.pprint :as pp]
    [clojure.set :as set]
    [clojure.string :as str]
-   [eastwood.analyze-ns :as analyze]
+   [eastwood.analyze-ns :as analyze-ns]
    [eastwood.copieddeps.dep11.clojure.java.classpath :as classpath]
    [eastwood.copieddeps.dep9.clojure.tools.namespace.dir :as dir]
    [eastwood.copieddeps.dep9.clojure.tools.namespace.file :as file]
@@ -128,7 +128,7 @@
        (map :name)))
 
 (defn namespace-info [ns-sym cwd-file]
-  (let [uri (util/to-uri (analyze/uri-for-ns ns-sym))]
+  (let [uri (util/to-uri (analyze-ns/uri-for-ns ns-sym))]
     (merge
      {:namespace-sym ns-sym}
      (util/file-warn-info uri cwd-file))))
@@ -179,7 +179,7 @@
                  :linter linter}))))
 
 (defn lint-ns [ns-sym linters opts]
-  (let [[result elapsed] (util/timeit (analyze/analyze-ns ns-sym :opt opts))
+  (let [[result elapsed] (util/timeit (analyze-ns/analyze-ns ns-sym :opt opts))
         {:keys [analyze-results exception exception-phase exception-form]} result]
     {:ns ns-sym
      :analysis-time elapsed
@@ -662,7 +662,7 @@ clojure.inspector/inspect-tree on it.  Example in REPL:
 (require '[eastwood.lint :as l] '[clojure.inspector :as i])
 (i/inspect-tree (l/insp 'testcases.f01))"
   [nssym]
-  (let [a (analyze/analyze-ns nssym :opt {:callback (fn [_]) :debug #{}})]
+  (let [a (analyze-ns/analyze-ns nssym :opt {:callback (fn [_]) :debug #{}})]
     (update-in a [:analyze-results :asts]
                (fn [ast] (mapv util/clean-ast ast)))))
 

--- a/src/eastwood/linters/deprecated.clj
+++ b/src/eastwood/linters/deprecated.clj
@@ -1,8 +1,10 @@
 (ns eastwood.linters.deprecated
   (:refer-clojure :exclude [get-method])
-  (:require [eastwood.passes :as pass]
-            [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast])
-  (:import (java.lang.reflect Method Constructor Field)))
+  (:require
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
+   [eastwood.passes :as pass])
+  (:import
+   (java.lang.reflect Constructor Field Method)))
 
 (defn no-constructor-found [ctor-info]
   (if (map? ctor-info)
@@ -110,5 +112,4 @@
                  :var (deprecated-var dexpr)}
               allow? (not (allow-warning w opt))]
         :when allow?]
-    w
-))
+    w))

--- a/src/eastwood/linters/implicit_dependencies.clj
+++ b/src/eastwood/linters/implicit_dependencies.clj
@@ -18,9 +18,9 @@
                                   (keep #(some-> % :macro namespace symbol))
                                   set)]
 
-    (not (empty? (disj macro-namespace-syms
-                       ns-sym
-                       'clojure.core)))))
+    (boolean (seq (disj macro-namespace-syms
+                        ns-sym
+                        'clojure.core)))))
 
 (defn implicit-dependencies [{:keys [asts forms] :as x} _]
   (let [ns-ast (first (util/ns-form-asts asts))

--- a/src/eastwood/linters/implicit_dependencies.clj
+++ b/src/eastwood/linters/implicit_dependencies.clj
@@ -1,8 +1,8 @@
 (ns eastwood.linters.implicit-dependencies
-  (:require [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
-            [eastwood.copieddeps.dep9.clojure.tools.namespace.parse :as ns-parse]
-            [eastwood.util :as util]))
-
+  (:require
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
+   [eastwood.copieddeps.dep9.clojure.tools.namespace.parse :as ns-parse]
+   [eastwood.util :as util]))
 
 (defn var->ns-symbol [var]
   (if (util/clojure-1-10-or-later)
@@ -10,7 +10,6 @@
     (symbol (namespace (symbol var)))
     (let [^clojure.lang.Namespace ns (-> var meta :ns)]
       (.-name ns))))
-
 
 (defn within-other-ns-macro?
   [ast ns-sym]
@@ -23,7 +22,6 @@
                        ns-sym
                        'clojure.core)))))
 
-
 (defn implicit-dependencies [{:keys [asts forms] :as x} _]
   (let [ns-ast (first (util/ns-form-asts asts))
         ns-decl (first (:raw-forms ns-ast))
@@ -33,7 +31,6 @@
                                     ns-sym
                                     ;;clojure core is always included in every namespace, no need to warn about it
                                     'clojure.core)]
-
 
     (->> asts
          (mapcat ast/nodes)

--- a/src/eastwood/linters/implicit_dependencies.clj
+++ b/src/eastwood/linters/implicit_dependencies.clj
@@ -1,7 +1,7 @@
 (ns eastwood.linters.implicit-dependencies
   (:require
    [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
-   [eastwood.copieddeps.dep9.clojure.tools.namespace.parse :as ns-parse]
+   [eastwood.copieddeps.dep9.clojure.tools.namespace.parse :as parse]
    [eastwood.util :as util]))
 
 (defn var->ns-symbol [var]
@@ -25,8 +25,8 @@
 (defn implicit-dependencies [{:keys [asts forms] :as x} _]
   (let [ns-ast (first (util/ns-form-asts asts))
         ns-decl (first (:raw-forms ns-ast))
-        ns-sym (ns-parse/name-from-ns-decl ns-decl)
-        namespace-dependency? (conj (ns-parse/deps-from-ns-decl ns-decl)
+        ns-sym (parse/name-from-ns-decl ns-decl)
+        namespace-dependency? (conj (parse/deps-from-ns-decl ns-decl)
                                     ;;consider namespace as part of itself
                                     ns-sym
                                     ;;clojure core is always included in every namespace, no need to warn about it

--- a/src/eastwood/linters/misc.clj
+++ b/src/eastwood/linters/misc.clj
@@ -95,7 +95,7 @@
 ;; Misplaced docstring
 
 (defn- misplaced-docstring? [expr]
-  (if-let [fn-ast (util/get-fn-in-def expr)]
+  (when-let [fn-ast (util/get-fn-in-def expr)]
     (some true?
           (for [method (-> fn-ast :methods)
                 :let [body (:body method)]
@@ -242,14 +242,14 @@
             ;; Don't bother calculating enclosing-macros if there are
             ;; no suppress-conditions to check, to save time.
             [lca-path lca-ast]
-            (if (seq suppress-conditions)
+            (when (seq suppress-conditions)
               (let [a (get-in all-asts lca-path)]
                 ;; If the lowest common ancestor is a vector, back up
                 ;; one step to the parent, which should be an AST.
                 (if (vector? a)
                   [(pop lca-path) (get-in all-asts (pop lca-path))]
                   [lca-path a])))
-            encl-macros (if (seq suppress-conditions)
+            encl-macros (when (seq suppress-conditions)
                           (util/enclosing-macros lca-ast))
 ;;            _ (do
 ;;                (println (format "dbg (count suppress-conditions)=%d"
@@ -395,7 +395,7 @@
                         (map argvec-kind arglists))
         ;; If there are multiple 'N args or more', keep only the one
         ;; with smallest N, since it is the most permissive.
-        n-or-more (if (seq (get kinds true))
+        n-or-more (when (seq (get kinds true))
                     (apply min (map second (get kinds true))))
         ;; If there are exact arg counts that are larger than the
         ;; smallest 'N args or more', remove them.  Sort any that are
@@ -715,8 +715,8 @@
 ;;                                  (more-restrictive-sigs? meta-sigs fn-sigs)))
 ;;                 )
                    loc (-> a var-of-ast meta)]
-               (if (and (not (nil? meta-arglists))
-                        (not (more-restrictive-sigs? meta-sigs fn-sigs)))
+               (when (and (not (nil? meta-arglists))
+                          (not (more-restrictive-sigs? meta-sigs fn-sigs)))
                  [{:loc loc
                    :linter :bad-arglists
                    :msg (format "%s on var %s defined taking # args %s but :arglists metadata has # args %s"
@@ -969,13 +969,13 @@
                       valid-but-unusual-flags (set/intersection flags valid-flags)
                       libspecs-or-prefix-lists (remove keyword? reference-args)]
                   (concat
-                   (if (seq invalid-flags)
+                   (when (seq invalid-flags)
                      [{:loc (most-specific-loc loc reference)
                        :linter :wrong-ns-form
                        :msg (format "%s contains unknown flags: %s - flags should only be the following: %s"
                                     kw (string/join " " (sort invalid-flags))
                                     (string/join " " (sort valid-flags)))}])
-                   (if (seq valid-but-unusual-flags)
+                   (when (seq valid-but-unusual-flags)
                      [{:loc (most-specific-loc loc reference)
                        :linter :wrong-ns-form
                        :msg (format "%s contains the following valid flags, but it is most common to use them interactively, not in ns forms: %s"

--- a/src/eastwood/linters/misc.clj
+++ b/src/eastwood/linters/misc.clj
@@ -6,7 +6,7 @@
    [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
    [eastwood.copieddeps.dep1.clojure.tools.analyzer.env :as env]
    [eastwood.copieddeps.dep1.clojure.tools.analyzer.utils :refer [dynamic? resolve-sym]]
-   [eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as j]
+   [eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as jvm]
    [eastwood.util :as util])
   (:import
    (java.io File)))
@@ -736,7 +736,7 @@
                    ;; the difference between that and (:tag fn) ?
                    (not= clojure.lang.AFunction (:tag fn))
                    (contains? (:locals env) (:form fn)))
-        :let [v (env/ensure (j/global-env) (resolve-sym (:form fn) env))]
+        :let [v (env/ensure (jvm/global-env) (resolve-sym (:form fn) env))]
         :when v]
     {:loc env
      :linter :local-shadows-var

--- a/src/eastwood/linters/typetags.clj
+++ b/src/eastwood/linters/typetags.clj
@@ -1,8 +1,9 @@
 (ns eastwood.linters.typetags
-  (:require [clojure.string :as string]
-            [eastwood.util :as util]
-            [eastwood.passes :as pass]
-            [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]))
+  (:require
+   [clojure.string :as string]
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
+   [eastwood.passes :as pass]
+   [eastwood.util :as util]))
 
 (def default-classname-mapping
   (ns-map 'eastwood.linters.typetags))
@@ -24,7 +25,6 @@ significance needed by the user."
                   #"@[0-9a-fA-F]+"
                   (string/re-quote-replacement "@<somehex>")))
 
-
 (def keys-indicating-wrong-tag #{:eastwood/name-tag
                                  :eastwood/tag
                                  :eastwood/o-tag
@@ -32,7 +32,6 @@ significance needed by the user."
 
 (defn has-wrong-tag? [ast]
   (some #(contains? ast %) keys-indicating-wrong-tag))
-
 
 (defn wrong-tag-from-analyzer [{:keys [asts]} opt]
   (for [{:keys [op name form env] :as ast} (->> (mapcat ast/nodes asts)
@@ -45,13 +44,13 @@ significance needed by the user."
               [typ tag loc]
               (cond (= wrong-tag-keys #{:eastwood/name-tag})
                     [:wrong-tag-on-var (-> name meta :tag) env]
-                    
+
                     (and (= wrong-tag-keys #{:eastwood/tag :eastwood/o-tag})
                          (= op :fn-method))
                     (let [m (or (pass/has-code-loc? (meta form))
                                 (pass/code-loc (pass/nearest-ast-with-loc ast)))]
                       [:fn-method (-> ast :eastwood/tag) m])
-                    
+
                     ;; This set of wrong-tag-keys sometimes occurs for
                     ;; op :local, but since those can be multiple
                     ;; times, one for each use, I am hoping I can make
@@ -102,7 +101,7 @@ significance needed by the user."
                     (and (= wrong-tag-keys #{:eastwood/return-tag})
                          (= op :var))
                     [:var (get ast :return-tag) env]
-                    
+
                     ;; I have seen this case for this form:
                     ;; (def avlf1 (fn ^{:tag 'LinkedList} [coll] (java.util.LinkedList. coll)))
                     ;; Without warning about this case, I believe one

--- a/src/eastwood/passes.clj
+++ b/src/eastwood/passes.clj
@@ -148,7 +148,7 @@ replaced by one that is resolved, with a namespace."
     (walk ast add-ancestors-pre add-ancestors-post)))
 
 (defn has-code-loc? [x]
-  (if (util/has-keys? x [:file :line :column])
+  (when (util/has-keys? x [:file :line :column])
     x))
 
 (defn code-loc [ast]

--- a/src/eastwood/passes.clj
+++ b/src/eastwood/passes.clj
@@ -1,12 +1,14 @@
 (ns eastwood.passes
   (:refer-clojure :exclude [get-method])
-  (:import [java.lang.reflect Method])
-  (:require [clojure.string :as str]
-            [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :refer [children* update-children prewalk postwalk walk]]
-            [eastwood.util :as util]
-            [eastwood.copieddeps.dep1.clojure.tools.analyzer.env :as env]
-            [eastwood.copieddeps.dep1.clojure.tools.analyzer.utils :as utils]
-            [eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as ana.jvm]))
+  (:require
+   [clojure.string :as str]
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :refer [children* postwalk prewalk update-children walk]]
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.env :as env]
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.utils :as utils]
+   [eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as ana.jvm]
+   [eastwood.util :as util])
+  (:import
+   (java.lang.reflect Method)))
 
 (defmulti reflect-validated :op)
 
@@ -55,11 +57,9 @@
             {:class cls, :method-name method-name,
              :arg-types arg-type-vec}))))))
 
-
 (defn void-method? [^Method m]
   (let [ret-val (.getGenericReturnType m)]
     (= ret-val Void/TYPE)))
-
 
 (defmethod reflect-validated :default [ast] ast)
 
@@ -132,7 +132,6 @@ replaced by one that is resolved, with a namespace."
                ast))]
     (postwalk ast pw)))
 
-
 (def ^:private ^:dynamic *ancestors*)
 
 (defn add-ancestors-pre [ast]
@@ -170,7 +169,6 @@ add-ancestors."
   (let [places (concat [ast] (util/nil-safe-rseq (:eastwood/ancestors ast)))]
     (filter code-loc places)))
 
-
 (defn add-path-pre* [path i ast]
   (assoc ast :eastwood/path (conj path i)))
 
@@ -189,6 +187,6 @@ add-ancestors."
 
 (defn add-path
   ([ast]
-     (add-path ast []))
+   (add-path ast []))
   ([ast root-path]
-     (prewalk (assoc ast :eastwood/path root-path) add-path-pre)))
+   (prewalk (assoc ast :eastwood/path root-path) add-path-pre)))

--- a/src/eastwood/passes.clj
+++ b/src/eastwood/passes.clj
@@ -5,7 +5,7 @@
    [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :refer [children* postwalk prewalk update-children walk]]
    [eastwood.copieddeps.dep1.clojure.tools.analyzer.env :as env]
    [eastwood.copieddeps.dep1.clojure.tools.analyzer.utils :as utils]
-   [eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as ana.jvm]
+   [eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as jvm]
    [eastwood.util :as util])
   (:import
    (java.lang.reflect Method)))
@@ -120,7 +120,7 @@ replaced by one that is resolved, with a namespace."
                      (mapv (fn [form]
                              (if (seq? form)
                                (let [[op & args] form
-                                     ^clojure.lang.Var var (env/ensure (ana.jvm/global-env)
+                                     ^clojure.lang.Var var (env/ensure (jvm/global-env)
                                                                        (utils/resolve-sym op env))
                                      resolved-var-sym (if (nil? var)
                                                         op

--- a/src/eastwood/reporting_callbacks.clj
+++ b/src/eastwood/reporting_callbacks.clj
@@ -1,8 +1,9 @@
 (ns eastwood.reporting-callbacks
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
-            [eastwood.error-messages :as msgs]
-            [eastwood.util :as util]))
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [eastwood.error-messages :as msgs]
+   [eastwood.util :as util]))
 
 (def last-cwd-shown (atom nil))
 
@@ -66,7 +67,7 @@
   (print (str msg "\n"))
   (flush))
 
-(defmethod note SilentReporter [reporter msg] )
+(defmethod note SilentReporter [reporter msg])
 
 (defmethod lint-warning SilentReporter [reporter warning])
 

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -5,8 +5,8 @@
    [clojure.repl :as repl]
    [clojure.set :as set]
    [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
-   [eastwood.copieddeps.dep10.clojure.tools.reader :as trdr]
-   [eastwood.copieddeps.dep10.clojure.tools.reader.reader-types :as rdr-types])
+   [eastwood.copieddeps.dep10.clojure.tools.reader :as reader]
+   [eastwood.copieddeps.dep10.clojure.tools.reader.reader-types :as reader-types])
   (:import
    (clojure.lang LineNumberingPushbackReader)
    (java.io File StringReader)
@@ -591,14 +591,14 @@ pprint-meta instead."
   string is in that same namespace.  Fortunately, this is pretty
   common for most Clojure code as written today."
   [s ns include-line-col-metadata?]
-  (binding [trdr/*data-readers* *data-readers*
+  (binding [reader/*data-readers* *data-readers*
             *ns* (or ns *ns*)]
     (let [rdr (if include-line-col-metadata?
                 (LineNumberingPushbackReader. (StringReader. s))
-                (rdr-types/string-push-back-reader s))
+                (reader-types/string-push-back-reader s))
           eof (reify)]
       (loop [forms []]
-        (let [x (trdr/read rdr nil eof)]
+        (let [x (reader/read rdr nil eof)]
           (if (identical? x eof)
             forms
             (recur (conj forms x))))))))

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -1,20 +1,21 @@
 (ns eastwood.util
-  (:require [clojure.java.io :as io]
-            [clojure.pprint :as pp]
-            [clojure.repl :as repl]
-            [clojure.set :as set]
-            [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
-            [eastwood.copieddeps.dep10.clojure.tools.reader :as trdr]
-            [eastwood.copieddeps.dep10.clojure.tools.reader.reader-types
-             :as
-             rdr-types])
-  (:import clojure.lang.LineNumberingPushbackReader
-           [java.io File StringReader]
-           java.net.URI))
+  (:require
+   [clojure.java.io :as io]
+   [clojure.pprint :as pp]
+   [clojure.repl :as repl]
+   [clojure.set :as set]
+   [eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast]
+   [eastwood.copieddeps.dep10.clojure.tools.reader :as trdr]
+   [eastwood.copieddeps.dep10.clojure.tools.reader.reader-types :as rdr-types])
+  (:import
+   (clojure.lang LineNumberingPushbackReader)
+   (java.io File StringReader)
+   (java.net URI)))
 
 (defmacro timeit
   "Evaluates expr and returns a vector containing the expression's
 return value followed by the time it took to evaluate in millisec."
+  {:style/indent 0}
   [expr]
   `(let [start# (. System (nanoTime))
          ret# ~expr
@@ -73,7 +74,6 @@ return value followed by the time it took to evaluate in millisec."
         (string? x) (.toURI (File. ^String x))
         :else (assert false)))
 
-
 (defn remove-prefix
   "If string s starts with the string prefix, return s with that
   prefix removed.  Otherwise, return s."
@@ -81,7 +81,6 @@ return value followed by the time it took to evaluate in millisec."
   (if (.startsWith s prefix)
     (subs s (count prefix))
     s))
-
 
 (defn file-warn-info [f cwd-file]
   (let [uri (to-uri f)
@@ -139,7 +138,6 @@ user=> (canonical-filename \"..\\..\\.\\clj\\..\\Documents\\.\\.\\\")
                           (java.io.File. ^String fname))]
     (.getCanonicalPath f)))
 
-
 ;; Copied from clojure.repl/pst then modified to 'print' using a
 ;; callback function, and to use depth nil to print all stack frames.
 
@@ -148,7 +146,7 @@ user=> (canonical-filename \"..\\..\\.\\clj\\..\\Documents\\.\\.\\\")
 entire stack trace if depth is nil).  Does not print ex-data."
   [^Throwable e depth]
   (println (str (-> e class .getSimpleName) " "
-                 (.getMessage e)))
+                (.getMessage e)))
   (let [st (.getStackTrace e)
         cause (.getCause e)]
     (doseq [el (remove #(#{"clojure.lang.RestFn" "clojure.lang.AFn"}
@@ -162,7 +160,6 @@ entire stack trace if depth is nil).  Does not print ex-data."
                         (+ 2 (- (count (.getStackTrace cause))
                                 (count st)))))))))
 
-
 ;; ordering-map copied under Eclipse Public License v1.0 from useful
 ;; library available at: https://github.com/flatland/useful
 
@@ -172,15 +169,15 @@ keys first, in the order specified. Other keys will be placed after
 the special keys, sorted by the default-comparator."
   ([key-order] (ordering-map key-order compare))
   ([key-order default-comparator]
-     (let [indices (into {} (map-indexed (fn [i x] [x i]) key-order))]
-       (sorted-map-by (fn [a b]
-                        (if-let [a-idx (indices a)]
-                          (if-let [b-idx (indices b)]
-                            (compare a-idx b-idx)
-                            -1)
-                          (if (indices b)
-                            1
-                            (default-comparator a b))))))))
+   (let [indices (into {} (map-indexed (fn [i x] [x i]) key-order))]
+     (sorted-map-by (fn [a b]
+                      (if-let [a-idx (indices a)]
+                        (if-let [b-idx (indices b)]
+                          (compare a-idx b-idx)
+                          -1)
+                        (if (indices b)
+                          1
+                          (default-comparator a b))))))))
 
 (defn ast-to-ordered
   "Take an ast and return an identical one, except every map is
@@ -241,23 +238,19 @@ more interesting keys earlier."
                           ;; exceptions due to incomparable keys.
                           ast)))))
 
-
 (defn all-children-vectors [asts]
   (->> asts
        (mapcat ast/nodes)
        (keep :children)
        frequencies))
 
-
 (defn has-keys? [m key-seq]
   (every? #(contains? m %) key-seq))
-
 
 (defn nil-safe-rseq [s]
   (if (nil? s)
     nil
     (rseq s)))
-
 
 (defn keys-in-map
   "Return the subset of key-set that are keys of map m, or nil if no
@@ -271,7 +264,6 @@ element of key-set is a key of m."
     (if (empty? keys-in-m)
       nil
       keys-in-m)))
-
 
 (defn sorted-map-with-non-keyword-keys? [x]
   (and (map? x)
@@ -288,7 +280,6 @@ element of key-set is a key of m."
        (not (sorted-map-with-non-keyword-keys? p))
        (has-keys? p [:on :on-interface :sigs :var :method-map
                      :method-builders])))
-
 
 (defn butlast+last
   "Returns same value as (juxt butlast last), but slightly more
@@ -325,7 +316,6 @@ twice."
       (recur (conj! ret (first s1)) (next s1) (next s2))
       (persistent! ret))))
 
-
 (defn separate-suffix
   "Given a string s and a sequence of strings, suffixes, return a
   vector of 2 strings [x y] where y is the first element of suffixes
@@ -334,7 +324,6 @@ twice."
   [^String s suffixes]
   (if-let [suffix (some #(if (.endsWith s %) %) suffixes)]
     [(subs s 0 (- (count s) (count suffix))) suffix]))
-
 
 (defn nth-last
   "Return the nth-last element of a vector v, where n=1 means the last
@@ -371,13 +360,13 @@ fewer than n elements in the vector."
   [inner outer form]
   (let [m (meta form)
         f (cond
-           (list? form) (apply list (map inner form))
-           (instance? clojure.lang.IMapEntry form) (vec (map inner form))
-           (seq? form) (doall (map inner form))
-           (instance? clojure.lang.IRecord form)
-             (reduce (fn [r x] (conj r (inner x))) form form)
-           (coll? form) (into (empty form) (map inner form))
-           :else form)]
+            (list? form) (apply list (map inner form))
+            (instance? clojure.lang.IMapEntry form) (vec (map inner form))
+            (seq? form) (doall (map inner form))
+            (instance? clojure.lang.IRecord form)
+            (reduce (fn [r x] (conj r (inner x))) form form)
+            (coll? form) (into (empty form) (map inner form))
+            :else form)]
     (if (and m (instance? clojure.lang.IObj f))
       (outer (with-meta f m))
       (outer f))))
@@ -426,8 +415,8 @@ http://dev.clojure.org/jira/browse/CLJ-1445"
         (fn pm [o]
           (let [o (if (protocol? o)
                     (assoc o
-                      :var :true-value-replaced-to-avoid-pprint-infinite-loop
-                      :method-builders :true-value-replaced-to-avoid-pprint-infinite-loop)
+                           :var :true-value-replaced-to-avoid-pprint-infinite-loop
+                           :method-builders :true-value-replaced-to-avoid-pprint-infinite-loop)
                     o)]
             (when (meta o)
               (print "^")
@@ -493,13 +482,13 @@ pprint-meta instead."
   (ast/postwalk ast (fn [ast]
                       (map-vals (fn [val]
                                   (cond
-                                   (protocol? val)
-                                   (dissoc val :var :method-builders)
+                                    (protocol? val)
+                                    (dissoc val :var :method-builders)
 
-                                   (and (var? val) (protocol? @val))
-                                   (dissoc @val :var :method-builders)
+                                    (and (var? val) (protocol? @val))
+                                    (dissoc @val :var :method-builders)
 
-                                   :else val))
+                                    :else val))
                                 ast))))
 
 (defn clean-ast [ast & kws]
@@ -654,42 +643,42 @@ pprint-meta instead."
   (if-not (= :try (:op ast))
     ast
     (if-not (some #{:body} (:children ast))
-        (do
-          (println (format "Found try node but it had no :body key in its :children, only %s"
-                           (seq (:children ast))))
-          (pprint-ast-node ast)
-          ast)
-        (let [body (:body ast)]
-          (if-not (= :do (:op body))
-            (update-in ast [:body]
-                       (fn [node]
-                         (assoc node
-                           :eastwood/used-ret-val-expr-in-try-body true)))
-            (let [;; Mark statements - i.e. non-returning expressions in body
-                  ast (if-not (and (some #{:statements} (:children body))
-                                   (vector? (:statements body)))
-                        (do
-                          (println (format "Found :try node with :body child that is :do, but either do has no :statements in children (only %s), or it does, but it is not a vector (it has class %s)"
-                                           (seq (:children body))
-                                           (class (:statements body))))
-                          (pprint-ast-node ast)
-                          ast)
-                        (update-in ast [:body :statements]
-                                   (fn [stmts]
-                                     (mapv #(assoc % :eastwood/unused-ret-val-expr-in-try-body true)
-                                           stmts))))
+      (do
+        (println (format "Found try node but it had no :body key in its :children, only %s"
+                         (seq (:children ast))))
+        (pprint-ast-node ast)
+        ast)
+      (let [body (:body ast)]
+        (if-not (= :do (:op body))
+          (update-in ast [:body]
+                     (fn [node]
+                       (assoc node
+                              :eastwood/used-ret-val-expr-in-try-body true)))
+          (let [;; Mark statements - i.e. non-returning expressions in body
+                ast (if-not (and (some #{:statements} (:children body))
+                                 (vector? (:statements body)))
+                      (do
+                        (println (format "Found :try node with :body child that is :do, but either do has no :statements in children (only %s), or it does, but it is not a vector (it has class %s)"
+                                         (seq (:children body))
+                                         (class (:statements body))))
+                        (pprint-ast-node ast)
+                        ast)
+                      (update-in ast [:body :statements]
+                                 (fn [stmts]
+                                   (mapv #(assoc % :eastwood/unused-ret-val-expr-in-try-body true)
+                                         stmts))))
                   ;; Mark the return expression
-                  ast (if-not (some #{:ret} (:children body))
-                        (do
-                          (println (format "Found :try node with :body child that is :do, but do has no :ret in children (only %s)"
-                                           (seq (:children body))))
-                          (pprint-ast-node ast)
-                          ast)
-                        (update-in ast [:body :ret]
-                                   (fn [node]
-                                     (assoc node
-                                       :eastwood/used-ret-val-expr-in-try-body true))))]
-              ast))))))
+                ast (if-not (some #{:ret} (:children body))
+                      (do
+                        (println (format "Found :try node with :body child that is :do, but do has no :ret in children (only %s)"
+                                         (seq (:children body))))
+                        (pprint-ast-node ast)
+                        ast)
+                      (update-in ast [:body :ret]
+                                 (fn [node]
+                                   (assoc node
+                                          :eastwood/used-ret-val-expr-in-try-body true))))]
+            ast))))))
 
 (defn mark-exprs-in-try-body
   "Return an ast that is identical to the argument, except that
@@ -756,16 +745,16 @@ of these kind."
 
 (defn get-val-in-map-ast
   ([map-ast k]
-     (get-val-in-map-ast map-ast k nil))
+   (get-val-in-map-ast map-ast k nil))
   ([map-ast k not-found]
-     {:pre [(map? map-ast)
-            (= :map (:op map-ast))
-            (vector? (:keys map-ast))
-            (vector? (:vals map-ast))]}
-     (if-let [idx (some #(if (= k (:form (second %))) (first %))
-                        (map-indexed vector (:keys map-ast)))]
-       ((:vals map-ast) idx)
-       not-found)))
+   {:pre [(map? map-ast)
+          (= :map (:op map-ast))
+          (vector? (:keys map-ast))
+          (vector? (:vals map-ast))]}
+   (if-let [idx (some #(if (= k (:form (second %))) (first %))
+                      (map-indexed vector (:keys map-ast)))]
+     ((:vals map-ast) idx)
+     not-found)))
 
 (defn debug? [debug-options opt]
   (when-let [d (:debug opt)]
@@ -773,7 +762,6 @@ of these kind."
         (and (set? debug-options)
              (some debug-options d))
         (contains? d debug-options))))
-
 
 (defn make-msg-cb
   "Tiny helper function to create a simple way to call the Eastwood callback function with only a message string.
@@ -787,13 +775,13 @@ message string."
   (fn [msg-str]
     ((:callback opt) {:kind kind, :msg msg-str, :opt opt})))
 
-
 (defmacro with-out-str2
   "Like with-out-str, but returns a map m.  (:val m) is the return
 value of the last expression in the body.  (:out m) is the string
 normally returned by with-out-str.  (:err m) is the string that would
 be returned by with-out-str if it bound *err* instead of *out* to a
 StringWriter."
+  {:style/indent 0}
   [& body]
   `(let [s# (new java.io.StringWriter)
          s2# (new java.io.StringWriter)
@@ -801,7 +789,6 @@ StringWriter."
                       *err* s2#]
               ~@body)]
      {:val x# :out (str s#) :err (str s2#)}))
-
 
 ;; TBD: There are some cases I have seen of calling this for every ast
 ;; warned about in the :constant-test linter, where the 'leaf' AST
@@ -825,10 +812,8 @@ StringWriter."
     (println (format "  form=%s" (:form a)))
     (println (format "  op=%s" (:op a)))))
 
-
 (def empty-enclosing-macro-map
-  (ordering-map [
-                 :depth
+  (ordering-map [:depth
                  :index
                  :final
                  :op
@@ -836,32 +821,30 @@ StringWriter."
                  :eastwood/path
                  :form
                  :first-only
-                 :ast
-                 ]))
+                 :ast]))
 
 (defn enclosing-macros
   [ast]
   (apply concat
-    (for [[i a] (map-indexed vector
-                             (cons ast
-                                   (nil-safe-rseq (-> ast :eastwood/ancestors))))]
-      (for [[j f] (map-indexed vector
-                               (reverse (:raw-forms a)))]
-        (into empty-enclosing-macro-map
-              {:depth i, :index j, :op (:op a), :ast a,
-               :eastwood/path (:eastwood/path a),
-               :form f, :resolved-form-meta (meta (:form a)),
-               :macro (fqsym-of-raw-form f)})))))
-
+         (for [[i a] (map-indexed vector
+                                  (cons ast
+                                        (nil-safe-rseq (-> ast :eastwood/ancestors))))]
+           (for [[j f] (map-indexed vector
+                                    (reverse (:raw-forms a)))]
+             (into empty-enclosing-macro-map
+                   {:depth i, :index j, :op (:op a), :ast a,
+                    :eastwood/path (:eastwood/path a),
+                    :form f, :resolved-form-meta (meta (:form a)),
+                    :macro (fqsym-of-raw-form f)})))))
 
 (defn debug-warning
   ([w ast opt extra-flags]
    (debug-warning w ast opt extra-flags nil))
   ([w ast opt extra-flags f]
    (let [d (cond
-            (not (:debug-warning opt)) false
-            (true? (:debug-warning opt)) #{}
-            :else (set (:debug-warning opt)))]
+             (not (:debug-warning opt)) false
+             (true? (:debug-warning opt)) #{}
+             :else (set (:debug-warning opt)))]
      (when d
        ((make-msg-cb :debug opt)
         (with-out-str
@@ -878,8 +861,8 @@ StringWriter."
               (pprint-ast-node ast)
               (println "(none specified to debug-warning fn)")))))))))
 
-
 ;; This atom is modified from the config files
+
 (def warning-enable-config-atom (atom []))
 
 (defn disable-warning [m]
@@ -912,10 +895,8 @@ StringWriter."
                          into (:symbol-matches m))))
           {} warning-enable-config))
 
-
 (defn builtin-config-to-resource [name]
   (io/resource (str "eastwood/config/" name)))
-
 
 (defn init-warning-enable-config [builtin-config-files config-files opt]
   (let [all-config-files (concat (map builtin-config-to-resource
@@ -934,7 +915,6 @@ StringWriter."
           (pst e nil))))
     (process-configs @warning-enable-config-atom)))
 
-
 (defn meets-suppress-condition [ast enclosing-macros condition]
   (let [macro-set (:if-inside-macroexpansion-of condition)
         depth (:within-depth condition)
@@ -946,7 +926,6 @@ StringWriter."
               {:matching-condition condition
                :matching-macro (:macro m)}))
           enclosing-macros)))
-
 
 (defn allow-warning-based-on-enclosing-macros [w linter suppress-desc
                                                suppress-conditions opt]
@@ -1002,7 +981,6 @@ StringWriter."
         (allow-warning-based-on-enclosing-macros
          w linter "" suppress-conditions opt)))))
 
-
 ;; Linters that use the info in resource file var-info.edn as of
 ;; Eastwood 0.2.2:
 
@@ -1026,7 +1004,6 @@ StringWriter."
 ;; like :side-effect :lazy-fn :pure-fn :pure-fn-if-fn-args-pure
 ;; :warn-if-ret-val-unused to determine whether an expression has an
 ;; unused return value.
-
 
 ;; For each namespace with at least one symbol as a key in
 ;; var-info.edn, print the following:
@@ -1059,8 +1036,7 @@ StringWriter."
                                             set)]))
                                (into {}))
         ns-names (into (sorted-set) (concat (keys file-vars-by-ns)
-                                            (keys loaded-vars-by-ns)))
-        ]
+                                            (keys loaded-vars-by-ns)))]
     (println "Clojure version " (clojure-version))
     (println)
     (println "Summary of contents of var-info.edn file:")
@@ -1098,40 +1074,39 @@ StringWriter."
             (doseq [name (sort file-but-not-loaded)]
               (println (format "            %s" name)))))))))
 
-
 (comment
 
 ;; This version tends to be much slower due to the size of the :env
 ;; data, and converting it all to strings.
-(def a2 (update-in a [:analyze-results :asts] (fn [ast] (mapv #(util/clean-ast % :with-env) ast))))
+  (def a2 (update-in a [:analyze-results :asts] (fn [ast] (mapv #(util/clean-ast % :with-env) ast))))
 
 ;; Older versions that may not be so useful any more, but kept here in
 ;; case there remains something useful.
 
-(def fn1 (:init (nth a 1)))
-(def locs1 (->> fn1 util/ast-nodes (filter (util/op= :local))))
-(#'un/unused-fn-args* fn1)
-(#'un/params (-> fn1 :methods first))
-(#'un/used-locals (-> fn1 :methods first :body util/ast-nodes))
+  (def fn1 (:init (nth a 1)))
+  (def locs1 (->> fn1 util/ast-nodes (filter (util/op= :local))))
+  (#'un/unused-fn-args* fn1)
+  (#'un/params (-> fn1 :methods first))
+  (#'un/used-locals (-> fn1 :methods first :body util/ast-nodes))
 
-(def fn4 (:init (nth a 4)))
-(def locs4 (->> fn4 util/ast-nodes (filter (util/op= :local))))
+  (def fn4 (:init (nth a 4)))
+  (def locs4 (->> fn4 util/ast-nodes (filter (util/op= :local))))
 
-(require '[eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as aj])
-(def form (read-string "
+  (require '[eastwood.copieddeps.dep2.clojure.tools.analyzer.jvm :as aj])
+  (def form (read-string "
 (defn fn-with-unused-args3 [x y z]
   (let [foo (fn [y z]
               (* y z))]
     (foo x y)))
 "))
-(def env (aj/empty-env))
-(def an (aj/analyze form env))
-(def meth1 (-> an :init :methods first))
-(def ret-expr-args (-> meth1 :body :ret :body :ret :args))
+  (def env (aj/empty-env))
+  (def an (aj/analyze form env))
+  (def meth1 (-> an :init :methods first))
+  (def ret-expr-args (-> meth1 :body :ret :body :ret :args))
 
-(map :name (:params meth1))
+  (map :name (:params meth1))
 ;;=> (x__#0 y__#0 z__#0)
-(map :name ret-expr-args)
+  (map :name ret-expr-args)
 ;;=> (x__#0 y__#-1)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1139,38 +1114,36 @@ StringWriter."
 ;; Some code useful for copying and pasting into a REPL for debugging
 ;; AST contents with clojure.inspector.
 
-(require '[clojure.inspector :as insp])
-(require '[eastwood.analyze-ns :as ana] :reload)
-(require '[eastwood.util :as util] :reload)
-(require '[eastwood.linters.unused :as un] :reload)
-(require '[eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast])
+  (require '[clojure.inspector :as insp])
+  (require '[eastwood.analyze-ns :as ana] :reload)
+  (require '[eastwood.util :as util] :reload)
+  (require '[eastwood.linters.unused :as un] :reload)
+  (require '[eastwood.copieddeps.dep1.clojure.tools.analyzer.ast :as ast])
 
-(defn has-resolved-op? [ast]
-  (contains? (-> ast :raw-forms first meta)
-             :eastwood.copieddeps.dep1.clojure.tools.analyzer/resolved-op))
+  (defn has-resolved-op? [ast]
+    (contains? (-> ast :raw-forms first meta)
+               :eastwood.copieddeps.dep1.clojure.tools.analyzer/resolved-op))
 
-(defn resolved-op-asts [asts]
-  (->> asts
-       (mapcat ast/nodes)
-       (filter has-resolved-op?)))
+  (defn resolved-op-asts [asts]
+    (->> asts
+         (mapcat ast/nodes)
+         (filter has-resolved-op?)))
 
-(defn resolved-ops [ast]
-  (map (fn [rf]
-         (-> rf meta
-             :eastwood.copieddeps.dep1.clojure.tools.analyzer/resolved-op))
-       (:raw-forms ast)))
+  (defn resolved-ops [ast]
+    (map (fn [rf]
+           (-> rf meta
+               :eastwood.copieddeps.dep1.clojure.tools.analyzer/resolved-op))
+         (:raw-forms ast)))
 
-(defn add-resolved-ops [ast]
-  (assoc ast
-    :resolved-ops-on-raw-forms
-    (resolved-ops ast)))
+  (defn add-resolved-ops [ast]
+    (assoc ast
+           :resolved-ops-on-raw-forms
+           (resolved-ops ast)))
 
-(def nssym 'testcases.f06)
-(def a (ana/analyze-ns nssym :opt {:callback (fn [_]) :debug #{}}))
-(def a2 (update-in a [:analyze-results :asts]
-                   (fn [asts]
-                     (mapv (fn [ast] (-> ast add-resolved-ops util/clean-ast))
-                           asts))))
-(insp/inspect-tree a2)
-
-)
+  (def nssym 'testcases.f06)
+  (def a (ana/analyze-ns nssym :opt {:callback (fn [_]) :debug #{}}))
+  (def a2 (update-in a [:analyze-results :asts]
+                     (fn [asts]
+                       (mapv (fn [ast] (-> ast add-resolved-ops util/clean-ast))
+                             asts))))
+  (insp/inspect-tree a2))

--- a/src/eastwood/version.clj
+++ b/src/eastwood/version.clj
@@ -1,7 +1,9 @@
 (ns eastwood.version
-  (:require [clojure.java.io :refer [reader resource]]
-            [clojure.string :refer [join]])
-  (:import java.io.PushbackReader))
+  (:require
+   [clojure.java.io :refer [reader resource]]
+   [clojure.string :refer [join]])
+  (:import
+   (java.io PushbackReader)))
 (let [version-file (resource "EASTWOOD_VERSION")]
   (when version-file
     (with-open [rdr (reader version-file)]

--- a/src/eastwood/versioncheck.clj
+++ b/src/eastwood/versioncheck.clj
@@ -4,9 +4,9 @@
 
 (def main
   (delay
-   (do
-     (require 'eastwood.lint)
-     (resolve (symbol "eastwood.lint/eastwood-from-cmdline")))))
+    (do
+      (require 'eastwood.lint)
+      (resolve (symbol "eastwood.lint/eastwood-from-cmdline")))))
 
 (defn run-eastwood [opts]
   (let [{:keys [major minor]} *clojure-version*]

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -1,12 +1,14 @@
 (ns eastwood.lint-test
-  (:use [clojure.test ])
-  (:require [eastwood.lint :as sut :refer :all]
-            [eastwood.copieddeps.dep11.clojure.java.classpath :as classpath]
-            [eastwood.util :as util]
-            [eastwood.copieddeps.dep9.clojure.tools.namespace.dir :as dir]
-            [eastwood.copieddeps.dep9.clojure.tools.namespace.track :as track]
-            [eastwood.reporting-callbacks :as reporting])
-  (:import java.io.File))
+  (:require
+   [clojure.test :refer :all]
+   [eastwood.copieddeps.dep11.clojure.java.classpath :as classpath]
+   [eastwood.copieddeps.dep9.clojure.tools.namespace.dir :as dir]
+   [eastwood.copieddeps.dep9.clojure.tools.namespace.track :as track]
+   [eastwood.lint :as sut :refer :all]
+   [eastwood.reporting-callbacks :as reporting]
+   [eastwood.util :as util])
+  (:import
+   (java.io File)))
 
 (deftest expand-ns-keywords-test
   (testing ""
@@ -49,7 +51,7 @@
             :test-paths #{"bar"}}
            (setup-lint-paths #{"lol"} #{"bar"}))))
   (testing "empty source/test paths yields classpath-directories"
-    (with-redefs [classpath/classpath-directories (fn [] [(File. "lol" )])]
+    (with-redefs [classpath/classpath-directories (fn [] [(File. "lol")])]
       (is (= {:source-paths #{(File. "lol")}
               :test-paths #{}}
              (setup-lint-paths nil nil))))))

--- a/test/eastwood/linter_executor_test.clj
+++ b/test/eastwood/linter_executor_test.clj
@@ -1,6 +1,7 @@
 (ns eastwood.linter-executor-test
-  (:require [clojure.test :refer :all]
-            [eastwood.lint]))
+  (:require
+   [clojure.test :refer :all]
+   [eastwood.lint]))
 
 (def proof (atom []))
 
@@ -12,7 +13,7 @@
                                                       :builtin-config-files input}))
                            (is (pred @proof))
                            ;; Avoid duplicate failure reports, did the tests fail:
-                           #_ true ;; temporarily disabled because of a false positive
+                           #_true ;; temporarily disabled because of a false positive
                            )
     "The custom `set-linter-executor!` successfully runs"
     ["linter_executor.clj"]

--- a/test/eastwood/test/analyze_ns_test.clj
+++ b/test/eastwood/test/analyze_ns_test.clj
@@ -1,10 +1,10 @@
 (ns eastwood.test.analyze-ns-test
   (:require
    [clojure.test :refer :all]
-   [eastwood.analyze-ns :as analyze]))
+   [eastwood.analyze-ns :as sut]))
 
 (deftest test3
-  (let [result (analyze/analyze-ns 'testcases.wrong-require :opt {:debug #{}})]
+  (let [result (sut/analyze-ns 'testcases.wrong-require :opt {:debug #{}})]
     (is (instance? java.io.FileNotFoundException (:exception result)))))
 
 (defn- int-reader [input]
@@ -13,12 +13,12 @@
 (deftest custom-data-readers
   (testing "it should fail if there are no data readers registered"
     (is (thrown-with-msg? Exception #"No reader function for tag my-int"
-                          (analyze/analyze-ns 'testcases.data-readers))))
+                          (sut/analyze-ns 'testcases.data-readers))))
 
   (testing "it should not fail when there is a data reader"
     ; the parser reader uses the same data-readers from clojure.core (which in
     ; practice are loaded by clojure.core/load-data-readers, but here in tests
     ; has a manual binding.
     (binding [clojure.core/*data-readers* {'my-int int-reader}]
-      (let [result (analyze/analyze-ns 'testcases.data-readers)]
+      (let [result (sut/analyze-ns 'testcases.data-readers)]
         (is (nil? (:exception result)))))))

--- a/test/eastwood/test/analyze_ns_test.clj
+++ b/test/eastwood/test/analyze_ns_test.clj
@@ -1,6 +1,7 @@
 (ns eastwood.test.analyze-ns-test
-  (:use [clojure.test])
-  (:require [eastwood.analyze-ns :as analyze]))
+  (:require
+   [clojure.test :refer :all]
+   [eastwood.analyze-ns :as analyze]))
 
 (deftest test3
   (let [result (analyze/analyze-ns 'testcases.wrong-require :opt {:debug #{}})]

--- a/test/eastwood/test/cc_compare.clj
+++ b/test/eastwood/test/cc_compare.clj
@@ -26,14 +26,13 @@
         ;; refs, and many others.
         (instance? Comparable x) (.getName (class x))
 
-        (or (instance? java.lang.Class x) 
+        (or (instance? java.lang.Class x)
             (instance? clojure.lang.Var x)) (.getName (class x))
 
         :else (throw
                (ex-info (format "cc-cmp does not implement comparison of values with class %s"
                                 (.getName (class x)))
                         {:value x}))))
-
 
 (defn cmp-seq-lexi
   "Compare sequences x and y in lexicographic order, using comparator
@@ -57,10 +56,10 @@ is less than, equal to, or greater than y."
         ;; Sequences contain same elements.  x = y
         0))))
 
-
 ;; The same result can be obtained by calling cmp-seq-lexi on two
 ;; vectors, but this one should allocate less memory comparing
 ;; vectors.
+
 (defn cmp-vec-lexi
   "Compare vectors x and y in lexicographic order, using comparator
 cmpf to compare elements from x and y to each other.  As a comparator
@@ -78,7 +77,7 @@ works for vectors."
       (if (== i len)
         ;; If all elements 0..(len-1) are same, shorter vector comes
         ;; first.
-        (compare x-len y-len) 
+        (compare x-len y-len)
         (let [c (cmpf (x i) (y i))]
           (if (zero? c)
             (recur (inc i))
@@ -102,7 +101,6 @@ integer if x is less than, equal to, or greater than y."
           (if (zero? c)
             (recur (inc i))
             c))))))
-
 
 (defn cc-cmp
   "cc-cmp compares two values x and y.  As a comparator, it returns a
@@ -174,5 +172,5 @@ above, e.g. Java arrays."
           ;; vectors, e.g. a vector and a list will be compared here.
           (= x-cls "clojure.lang.Sequential")
           (cmp-seq-lexi cc-cmp x y)
-          
+
           :else (compare x y))))

--- a/test/eastwood/test/implicit_dependencies_linter_test.clj
+++ b/test/eastwood/test/implicit_dependencies_linter_test.clj
@@ -1,7 +1,8 @@
 (ns eastwood.test.implicit-dependencies-linter-test
-  (:require [clojure.test :refer :all]
-            [eastwood.util :as util]
-            [eastwood.test.linters-test :as linters-test]))
+  (:require
+   [clojure.test :refer :all]
+   [eastwood.test.linters-test :as linters-test]
+   [eastwood.util :as util]))
 
 (deftest implicit-dependency-linter
   (linters-test/lint-test


### PR DESCRIPTION
The lack of standardized formatting was making working on the codebase a bit painful - normally no-formatting means that I have to disable autoformatting, which in turns makes me format my changes manually.

Also the occasional choice of ns-aliases would confuse me :)

Commit summary:

* Reformat src, test
  * Used:
    * cljfmt
    * refactor-nrepl for removing unused imports
    * [how-to-ns](https://github.com/gfredericks/how-to-ns)
* Follow https://stuartsierra.com/2015/05/10/clojure-namespace-aliases
* Address some clj-kondo faults

All this was accomplished quite effortlessly with the tooling setup I happen to have at hand. Feedback welcome, I'd be happy to tweak things.

This PR's (low) impact can be best assessed by using `Hide whitespace changes`.