### PR TITLE
`:bad-arglists`: fix false positive for defns with `^:test` metadata

### DIFF
--- a/cases/testcases/test_metadata_example.clj
+++ b/cases/testcases/test_metadata_example.clj
@@ -1,0 +1,11 @@
+(ns testcases.test-metadata-example
+  "Exercises a defn with `:test` metadata"
+  (:require
+   [clojure.test :refer [is]]))
+
+(defn foo
+  {:test (fn []
+           (is (= 42
+                  (foo 21))))}
+  [x]
+  (* 2 x))

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,11 @@
 # Change log for Eastwood
 
+## Changes from 0.4.0 to 
+
+#### Bugfixes
+
+* Vanilla `defn`s having `:test` metadata don't result in false positives for the `:bad-arglists` linter anymore. 
+
 ## Changes from 0.3.14 to 0.4.0 
 
 #### New

--- a/src/eastwood/linters/misc.clj
+++ b/src/eastwood/linters/misc.clj
@@ -692,7 +692,8 @@
                                        (maybe-unwrap-quote
                                         (-> a :meta :val :arglists))
                                  ;; see case 2 notes above
-                                       (and (contains? (-> a :meta) :keys)
+                                       (and (not (-> a :var meta :arglists))
+                                            (contains? (-> a :meta) :keys)
                                             (->> (-> a :meta :keys)
                                                  (some #(= :test (get % :val)))))
                                        [[]]

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -163,3 +163,8 @@ The ignored-faults must match ns (exactly) and file/column (exactly, but only if
   (testing "Processing a namespace where `^:const` is used results in no exceptions being thrown"
     (is (= {:some-warnings false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.const}))))))
+
+(deftest test-metadata-handling
+  (testing "Processing a vanilla defn where `^:test` is used results in no linter faults"
+    (is (= {:some-warnings false}
+           (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.test-metadata-example}))))))


### PR DESCRIPTION
- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
