### PR TITLE
Make the `:suspicious-test` linter omittable

### DIFF
--- a/cases/testcases/are_true/green.clj
+++ b/cases/testcases/are_true/green.clj
@@ -1,0 +1,25 @@
+(ns testcases.are-true.green
+  (:require
+   [clojure.test :refer [are deftest is join-fixtures testing use-fixtures]]))
+
+(deftest foo
+  (are [a b expected] (testing [a b]
+                        (is (= expected
+                               (+ a b)))
+                        true)
+    1 2 3))
+
+(deftest bar
+  (are [a b expected] (do
+                        (is (= expected
+                               (+ a b)))
+                        true)
+    1 2 3))
+
+(deftest baz
+  (are [a b expected] (let [x [a b]]
+                        (is (= expected
+                               (+ a b))
+                            (pr-str x))
+                        true)
+    1 2 3))

--- a/cases/testcases/are_true/red_one.clj
+++ b/cases/testcases/are_true/red_one.clj
@@ -1,0 +1,7 @@
+(ns testcases.are-true.red-one
+  (:require
+   [clojure.test :refer [are deftest is join-fixtures testing use-fixtures]]))
+
+(deftest foo
+  (are [a b expected] true
+    1 2 3))

--- a/cases/testcases/are_true/red_three.clj
+++ b/cases/testcases/are_true/red_three.clj
@@ -1,0 +1,26 @@
+(ns testcases.are-true.red-three
+  "Uses `::true` instead of `true` (the `:qualifier` value) so this corpus will fail Eastwood."
+  (:require
+   [clojure.test :refer [are deftest is join-fixtures testing use-fixtures]]))
+
+(deftest foo
+  (are [a b expected] (testing [a b]
+                        (is (= expected
+                               (+ a b)))
+                        ::true)
+    1 2 3))
+
+(deftest bar
+  (are [a b expected] (do
+                        (is (= expected
+                               (+ a b)))
+                        ::true)
+    1 2 3))
+
+(deftest baz
+  (are [a b expected] (let [x [a b]]
+                        (is (= expected
+                               (+ a b))
+                            (pr-str x))
+                        ::true)
+    1 2 3))

--- a/cases/testcases/are_true/red_two.clj
+++ b/cases/testcases/are_true/red_two.clj
@@ -1,0 +1,9 @@
+(ns testcases.are-true.red-two
+  (:require
+   [clojure.test :refer [are deftest is join-fixtures testing use-fixtures]]))
+
+(deftest foo
+  (are [a b expected] (do
+                        (is true)
+                        true)
+    1 2 3))

--- a/changes.md
+++ b/changes.md
@@ -6,6 +6,8 @@
 
 * Now the `:wrong-tag` linter can also be configured via the [`disable-warning`](https://github.com/jonase/eastwood#eastwood-config-files) mechanism.
   * Related: the `disable-warnings` that Eastwood ships by default now prevent false positives against the [speced.def](https://github.com/nedap/speced.def) lib. 
+* Now the `:suspicious-test` linter can also be configured via the [`disable-warning`](https://github.com/jonase/eastwood#eastwood-config-files) mechanism.
+  * Relatedly, a certain pattern of usage of the `clojure.test/are` macro now does not trigger a linter fault. 
 
 #### Bugfixes
 

--- a/resource/eastwood/config/clojure.clj
+++ b/resource/eastwood/config/clojure.clj
@@ -68,3 +68,11 @@
    :function-symbol 'clojure.core/eduction
    :arglists-for-linting '([& xform])
    :reason "eduction takes a sequence of transducer with a collection as the last item"})
+
+(disable-warning
+ {:linter :suspicious-test
+  :if-inside-macroexpansion-of #{'clojure.test/are}
+  ;; only omit the warning if :suspicious-test failed due to a `true` value:
+  :qualifier true
+  :within-depth 9
+  :reason "Support a specific pattern that tends to fail better."})

--- a/src/eastwood/linters/misc.clj
+++ b/src/eastwood/linters/misc.clj
@@ -257,7 +257,7 @@
 ;;                (println (format "  :op=%s" (:op lca-ast)))
 ;;                (println (format "  :form=%s" (:form lca-ast)))
 ;;                )
-            match (some #(util/meets-suppress-condition lca-ast encl-macros %)
+            match (some #(util/meets-suppress-condition lca-ast encl-macros :eastwood/unset %)
                         suppress-conditions)]
         ;; (if (and match (:debug-suppression opt))
         ;;   ((util/make-msg-cb :debug opt)

--- a/test/eastwood/analyze_ns_test.clj
+++ b/test/eastwood/analyze_ns_test.clj
@@ -8,8 +8,9 @@
     (are [f input expected] (let [result (f input)]
                               (is (= result input)
                                   "Applying `f` should return an equivalent object (even after removing metadata)")
-                              (= expected
-                                 (-> result second meta :const)))
+                              (is (= expected
+                                     (-> result second meta :const)))
+                              true)
       identity    '(defn ^:const foo) true
       sut/cleanup '(defn ^:const foo) nil
       sut/cleanup '(defn foo)         nil)))

--- a/test/eastwood/linter_executor_test.clj
+++ b/test/eastwood/linter_executor_test.clj
@@ -6,15 +6,15 @@
 (def proof (atom []))
 
 (deftest works
-  (are [desc input pred] (testing [desc input]
+  (are [desc input pred] (testing input
                            (reset! proof [])
                            (with-out-str
                              (eastwood.lint/eastwood {:namespaces ['eastwood.test.linter-executor.sample-ns]
                                                       :builtin-config-files input}))
-                           (is (pred @proof))
+                           (is (pred @proof)
+                               desc)
                            ;; Avoid duplicate failure reports, did the tests fail:
-                           #_true ;; temporarily disabled because of a false positive
-                           )
+                           true)
     "The custom `set-linter-executor!` successfully runs"
     ["linter_executor.clj"]
     seq


### PR DESCRIPTION
Supports a specific `clojure.test/are` pattern, as shown in the included tests.

...This pattern tends to fail better (else a test failure would show up twice), which is why it's a good idea for Eastwood to support it.

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
