### PR TITLE
Make the `:wrong-tag` linter omittable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run:
           name: Fetch dependencies
           command: |
-            lein deps
+            lein with-profile +test,+test-3rd-party-deps, deps
             
       - save_cache:
           paths:
@@ -60,8 +60,40 @@ jobs:
           command:  git clean -fdx
                   
       - run:
-          name: Run test suite
+          name: Run normal test suite
           command: lein with-profile -user,-dev,+test,+warn-on-reflection,+<< parameters.clojure-version >> do clean, test
+      
+  test_third_party_deps:
+    parameters:
+      executor:
+        type: executor
+      clojure-version:
+        type: string
+    executor: << parameters.executor >>
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "project.clj" }}
+
+      - run:
+          name: Fetch dependencies
+          command: |
+            lein with-profile +test,+test-3rd-party-deps, deps
+            
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "project.clj" }}
+
+      - run:
+          name: Prevent any form of caching, for the next step
+          command:  git clean -fdx
+                  
+      - run:
+          name: Run test suite that exercises 3rd-party libs
+          command: lein with-profile -user,-dev,+test,+warn-on-reflection,+test-3rd-party-deps,+<< parameters.clojure-version >> do clean, test
 
 workflows:
   default:
@@ -70,4 +102,12 @@ workflows:
           matrix:
             parameters:
               executor: [openjdk8, openjdk11]
-              clojure-version: ["1.7", "1.8", "1.9", "1.10.1", "1.10.2"]
+              clojure-version: ["1.7", "1.8", "1.9", "1.10.1", "1.10.2", "1.10.3"]
+      # the `test_third_party_deps` profile uses a separate matrix because the contained libs (especially the ones that use clojure.spec)
+      # don't target older versions.
+      - test_third_party_deps:
+          matrix:
+            parameters:
+              executor: [openjdk8, openjdk11]
+              # Run just the latest version. This saves resources trusts that the main test suite already exercises clojure compat sufficiently:
+              clojure-version: ["1.10.3"]

--- a/cases/testcases/wrong_tag_example.clj
+++ b/cases/testcases/wrong_tag_example.clj
@@ -1,0 +1,7 @@
+(ns testcases.wrong-tag-example)
+
+(defmacro the-macro [n x]
+  `(defn ~n ~(with-meta [] {:tag pos?})
+     ~x))
+
+(the-macro foo 42)

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,11 @@
 
 ## Changes from 0.4.0 to 
 
+#### New
+
+* Now the `:wrong-tag` linter can also be configured via the [`disable-warning`](https://github.com/jonase/eastwood#eastwood-config-files) mechanism.
+  * Related: the `disable-warnings` that Eastwood ships by default now prevent false positives against the [speced.def](https://github.com/nedap/speced.def) lib. 
+
 #### Bugfixes
 
 * Vanilla `defn`s having `:test` metadata don't result in false positives for the `:bad-arglists` linter anymore. 

--- a/project.clj
+++ b/project.clj
@@ -17,16 +17,23 @@
                                   [jafingerhut/dolly "0.1.0"]]}
              :eastwood-plugin {:source-paths [~plugin-source-path]}
              :warn-on-reflection {:global-vars {*warn-on-reflection* true}}
-             :test {:dependencies [[commons-io "2.4" #_"Needed for issue-173-test"]]
+             :test {:dependencies
+                    ;; NOTE: please don't add non-essential 3rd-party deps here.
+                    ;; It is desirable to rest assured that the test suite does not depend on a third-party lib.
+                    ;; If you wish to exercise compatibility against a 3rd-party lib, use the `:test-3rd-party-deps` profile instead.
+                    [[commons-io "2.4" #_"Needed for issue-173-test"]]
                     :resource-paths ["test-resources"
                                      ;; if wanting the `cases` to be available during development / the default profile,
                                      ;; please simply add `with-profile +test` to your CLI invocation.
                                      "cases"]}
+             :test-3rd-party-deps {:test-paths ^:replace ["test-third-party-deps"]
+                                   :dependencies [[com.nedap.staffing-solutions/speced.def "2.0.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10.1 {:dependencies [[org.clojure/clojure "1.10.1"]]}
-             :1.10.2 {:dependencies [[org.clojure/clojure "1.10.2"]]}}
+             :1.10.2 {:dependencies [[org.clojure/clojure "1.10.2"]]}
+             :1.10.3 {:dependencies [[org.clojure/clojure "1.10.3"]]}}
   :aliases {"test-all" ["with-profile"
                         ~(->> ["1.7" "1.8" "1.9" "1.10"]
                               (map (partial str "-user,-dev,+test,+warn-on-reflection,+"))

--- a/resource/eastwood/config/third-party-libs.clj
+++ b/resource/eastwood/config/third-party-libs.clj
@@ -197,8 +197,7 @@
                          ([] [a b])]
 
                         [[hiccup.test.def/three-forms-extra]
-                         ([] [a] [a b])]
-                       )]
+                         ([] [a] [a b])])]
   ;; hiccup defelem's allow an optional first map argument
   (let [defelem-modified-arglists (concat arglist
                                           (map #(vec (cons 'attr-map? %))
@@ -310,3 +309,23 @@
   :if-inside-macroexpansion-of #{'slingshot.slingshot/try+}
   :within-depth 15
   :reason "slingshot.slingshot/try+ generates an (and ...) with one or more arguments. Suppress the 'and called with 1 args' warning."})
+
+(disable-warning
+ {:linter :constant-test
+  :for-macro 'clojure.core/if
+  :if-inside-macroexpansion-of '#{nedap.speced.def/defn
+                                  nedap.speced.def/defprotocol
+                                  nedap.speced.def/let
+                                  nedap.speced.def/letfn
+                                  nedap.speced.def/fn}
+  :within-depth 13
+  :reason "The emitted code emits an (if (class? x) ...) where x may be a class or a protocol. The result cannot be known at compile-time (especially as classes and protocols can be defined in runtime)."})
+
+(disable-warning
+ {:linter :wrong-tag
+  :if-inside-macroexpansion-of '#{nedap.speced.def/defn
+                                  nedap.speced.def/defprotocol
+                                  nedap.speced.def/let
+                                  nedap.speced.def/letfn
+                                  nedap.speced.def/fn}
+  :reason "The speced.def library uses an extended meaning for tag syntax."})

--- a/src/eastwood/linters/typetags.clj
+++ b/src/eastwood/linters/typetags.clj
@@ -34,129 +34,132 @@ significance needed by the user."
   (some #(contains? ast %) keys-indicating-wrong-tag))
 
 (defn wrong-tag-from-analyzer [{:keys [asts]} opt]
-  (for [{:keys [op name form env] :as ast} (->> (mapcat ast/nodes asts)
-                                                (filter has-wrong-tag?))
-        :let [wrong-tag-keys (util/keys-in-map keys-indicating-wrong-tag ast)
-;;              _ (do
-;;                  (when wrong-tag-keys
-;;                    (println (format "jafinger-dbg1: op=%s name=%s wrong-tag-keys=%s"
-;;                                     op name wrong-tag-keys))))
-              [typ tag loc]
-              (cond (= wrong-tag-keys #{:eastwood/name-tag})
-                    [:wrong-tag-on-var (-> name meta :tag) env]
+  (keep identity (for [{:keys [op name form env] :as ast} (->> (mapcat ast/nodes asts)
+                                                               (filter has-wrong-tag?))
+                       :let [wrong-tag-keys (util/keys-in-map keys-indicating-wrong-tag ast)
+                             ;;              _ (do
+                             ;;                  (when wrong-tag-keys
+                             ;;                    (println (format "jafinger-dbg1: op=%s name=%s wrong-tag-keys=%s"
+                             ;;                                     op name wrong-tag-keys))))
+                             [typ tag loc]
+                             (cond (= wrong-tag-keys #{:eastwood/name-tag})
+                                   [:wrong-tag-on-var (-> name meta :tag) env]
 
-                    (and (= wrong-tag-keys #{:eastwood/tag :eastwood/o-tag})
-                         (= op :fn-method))
-                    (let [m (or (pass/has-code-loc? (meta form))
-                                (pass/code-loc (pass/nearest-ast-with-loc ast)))]
-                      [:fn-method (-> ast :eastwood/tag) m])
+                                   (and (= wrong-tag-keys #{:eastwood/tag :eastwood/o-tag})
+                                        (= op :fn-method))
+                                   (let [m (or (pass/has-code-loc? (meta form))
+                                               (pass/code-loc (pass/nearest-ast-with-loc ast)))]
+                                     [:fn-method (-> ast :eastwood/tag) m])
 
-                    ;; This set of wrong-tag-keys sometimes occurs for
-                    ;; op :local, but since those can be multiple
-                    ;; times, one for each use, I am hoping I can make
-                    ;; the warnings less redundant by restricting them
-                    ;; to the :binding ops (checked for below), and
-                    ;; still not lose any important warnings.
-                    ;; This can also occur for op :quote, but in the
-                    ;; case that I have seen this occur so far
-                    ;; (Prismatic's Schema library), the wrong tag was
-                    ;; also detected on other 'nearby' ASTs, so
-                    ;; ignoring the op :quote one seems to avoid
-                    ;; duplicate warnings while still reporting the
-                    ;; issue.
-                    (and (= wrong-tag-keys #{:eastwood/tag :eastwood/o-tag})
-                         (#{:local :quote} op))
-                    [nil nil nil]
+                                   ;; This set of wrong-tag-keys sometimes occurs for
+                                   ;; op :local, but since those can be multiple
+                                   ;; times, one for each use, I am hoping I can make
+                                   ;; the warnings less redundant by restricting them
+                                   ;; to the :binding ops (checked for below), and
+                                   ;; still not lose any important warnings.
+                                   ;; This can also occur for op :quote, but in the
+                                   ;; case that I have seen this occur so far
+                                   ;; (Prismatic's Schema library), the wrong tag was
+                                   ;; also detected on other 'nearby' ASTs, so
+                                   ;; ignoring the op :quote one seems to avoid
+                                   ;; duplicate warnings while still reporting the
+                                   ;; issue.
+                                   (and (= wrong-tag-keys #{:eastwood/tag :eastwood/o-tag})
+                                        (#{:local :quote} op))
+                                   [nil nil nil]
 
-                    ;; This started appearing with Clojure 1.8.0 due
-                    ;; to the :rettag changes.  See
-                    ;; eastwood.util/get-fn-in-def for some more
-                    ;; details of this change.
-                    (and (= wrong-tag-keys #{:eastwood/return-tag})
-                         (#{:with-meta} op))
-                    [nil nil nil]
+                                   ;; This started appearing with Clojure 1.8.0 due
+                                   ;; to the :rettag changes.  See
+                                   ;; eastwood.util/get-fn-in-def for some more
+                                   ;; details of this change.
+                                   (and (= wrong-tag-keys #{:eastwood/return-tag})
+                                        (#{:with-meta} op))
+                                   [nil nil nil]
 
-                    (and (= wrong-tag-keys #{:eastwood/tag :eastwood/o-tag})
-                         (= op :invoke))
-                    [:invoke (-> ast :tag) (meta form)]
+                                   (and (= wrong-tag-keys #{:eastwood/tag :eastwood/o-tag})
+                                        (= op :invoke))
+                                   [:invoke (-> ast :tag) (meta form)]
 
-                    (or (and (= wrong-tag-keys #{:eastwood/tag :eastwood/o-tag})
-                             (#{:binding :do} op))
-                        (and (= wrong-tag-keys #{:eastwood/tag})
-                             (#{:local :const :var} op)))
-                    [:tag (get ast :tag)
-                     (or (pass/has-code-loc? (meta form))
-                         (pass/code-loc (pass/nearest-ast-with-loc ast)))]
+                                   (or (and (= wrong-tag-keys #{:eastwood/tag :eastwood/o-tag})
+                                            (#{:binding :do} op))
+                                       (and (= wrong-tag-keys #{:eastwood/tag})
+                                            (#{:local :const :var} op)))
+                                   [:tag (get ast :tag)
+                                    (or (pass/has-code-loc? (meta form))
+                                        (pass/code-loc (pass/nearest-ast-with-loc ast)))]
 
-                    ;; So far I have only seen this case in ztellman's
-                    ;; byte-streams library, and the warnings from a
-                    ;; different case were more clear and closer to
-                    ;; the source of the problem.  At least for now,
-                    ;; don't issue warnings for this case.
-                    (and (= wrong-tag-keys #{:eastwood/o-tag})
-                         (#{:local} op))
-                    ;;[:tag (get ast :o-tag) (meta form)]
-                    [nil nil nil]
+                                   ;; So far I have only seen this case in ztellman's
+                                   ;; byte-streams library, and the warnings from a
+                                   ;; different case were more clear and closer to
+                                   ;; the source of the problem.  At least for now,
+                                   ;; don't issue warnings for this case.
+                                   (and (= wrong-tag-keys #{:eastwood/o-tag})
+                                        (#{:local} op))
+                                   ;;[:tag (get ast :o-tag) (meta form)]
+                                   [nil nil nil]
 
-                    (and (= wrong-tag-keys #{:eastwood/return-tag})
-                         (= op :var))
-                    [:var (get ast :return-tag) env]
+                                   (and (= wrong-tag-keys #{:eastwood/return-tag})
+                                        (= op :var))
+                                   [:var (get ast :return-tag) env]
 
-                    ;; I have seen this case for this form:
-                    ;; (def avlf1 (fn ^{:tag 'LinkedList} [coll] (java.util.LinkedList. coll)))
-                    ;; Without warning about this case, I believe one
-                    ;; of the other cases already issues a warning for
-                    ;; this.
-                    (and (= wrong-tag-keys #{:eastwood/return-tag})
-                         (or (#{:def :fn} op)
-                             (and (= :do op)
-                                  (= [] (:statements ast))
-                                  (= :fn (-> ast :ret :op)))))
-                    [nil nil nil]
-                    ;;[:var (get ast :return-tag) env]
+                                   ;; I have seen this case for this form:
+                                   ;; (def avlf1 (fn ^{:tag 'LinkedList} [coll] (java.util.LinkedList. coll)))
+                                   ;; Without warning about this case, I believe one
+                                   ;; of the other cases already issues a warning for
+                                   ;; this.
+                                   (and (= wrong-tag-keys #{:eastwood/return-tag})
+                                        (or (#{:def :fn} op)
+                                            (and (= :do op)
+                                                 (= [] (:statements ast))
+                                                 (= :fn (-> ast :ret :op)))))
+                                   [nil nil nil]
+                                   ;;[:var (get ast :return-tag) env]
 
-                    :else
-                    (do
-                      ;; Use this to help detect wrong-tag cases I may
-                      ;; be missing completely.
-                      (println (format "eastwood-dbg: wrong-tag-from-analyzer: op=%s name=%s wrong-tag-keys=%s env=%s ast="
-                                       op name wrong-tag-keys env))
-                      (util/pprint-ast-node ast)
-                      (flush)
-                      (assert false)
-                      [nil nil nil]))
-              _ (when (and typ (not (util/has-keys? loc #{:file :line :column})))
-                  (println (format "eastwood-dbg: wrong-tag-no-loc: op=%s name=%s wrong-tag-keys=%s typ=%s tag=%s loc=%s ast="
-                                   op name wrong-tag-keys
-                                   typ tag loc))
-                  (util/pprint-ast-node ast))
-;;              _ (do
-;;                  (println (format "jafinger-dbg2: typ=%s tag=%s loc=%s"
-;;                                   typ tag loc))
-;;                  )
-              ]
-        :when typ]
-    {:loc loc
-     :linter :wrong-tag
-     :msg
-     (case typ
-       :wrong-tag-on-var (format "Wrong tag: %s in def of Var: %s"
-                                 (replace-variable-tag-part (eval tag))
-                                 name)
-       :tag (format "Wrong tag: %s on form: %s"
-                    (replace-variable-tag-part tag)
-                    form)
-       :var (format "Wrong tag: %s for form: %s, probably where the Var %s was def'd in namespace %s"
-                    (replace-variable-tag-part tag)
-                    form
-                    (-> ast :var meta :name)
-                    (-> ast :var meta :ns))
-       :invoke (format "Tag: %s for return type of function %s should be Java class name (fully qualified if not in java.lang package).  It may be defined in another namespace."
-                       (replace-variable-tag-part tag)
-                       (-> form first))
-       :fn-method (format "Tag: %s for return type of function method: %s should be Java class name (fully qualified if not in java.lang package)"
-                          (replace-variable-tag-part tag)
-                          form))}))
+                                   :else
+                                   (do
+                                     ;; Use this to help detect wrong-tag cases I may
+                                     ;; be missing completely.
+                                     (println (format "eastwood-dbg: wrong-tag-from-analyzer: op=%s name=%s wrong-tag-keys=%s env=%s ast="
+                                                      op name wrong-tag-keys env))
+                                     (util/pprint-ast-node ast)
+                                     (flush)
+                                     (assert false)
+                                     [nil nil nil]))
+                             _ (when (and typ (not (util/has-keys? loc #{:file :line :column})))
+                                 (println (format "eastwood-dbg: wrong-tag-no-loc: op=%s name=%s wrong-tag-keys=%s typ=%s tag=%s loc=%s ast="
+                                                  op name wrong-tag-keys
+                                                  typ tag loc))
+                                 (util/pprint-ast-node ast))
+                             ;;              _ (do
+                             ;;                  (println (format "jafinger-dbg2: typ=%s tag=%s loc=%s"
+                             ;;                                   typ tag loc))
+                             ;;                  )
+                             ]
+                       :when typ]
+                   (let [warning {:loc loc
+                                  :linter :wrong-tag
+                                  :wrong-tag {:ast ast}
+                                  :msg
+                                  (case typ
+                                    :wrong-tag-on-var (format "Wrong tag: %s in def of Var: %s"
+                                                              (replace-variable-tag-part (eval tag))
+                                                              name)
+                                    :tag (format "Wrong tag: %s on form: %s"
+                                                 (replace-variable-tag-part tag)
+                                                 form)
+                                    :var (format "Wrong tag: %s for form: %s, probably where the Var %s was def'd in namespace %s"
+                                                 (replace-variable-tag-part tag)
+                                                 form
+                                                 (-> ast :var meta :name)
+                                                 (-> ast :var meta :ns))
+                                    :invoke (format "Tag: %s for return type of function %s should be Java class name (fully qualified if not in java.lang package).  It may be defined in another namespace."
+                                                    (replace-variable-tag-part tag)
+                                                    (-> form first))
+                                    :fn-method (format "Tag: %s for return type of function method: %s should be Java class name (fully qualified if not in java.lang package)"
+                                                       (replace-variable-tag-part tag)
+                                                       form))}]
+                     (when (util/allow-warning warning opt)
+                       warning)))))
 
 (defn fq-classname-to-class [cname-str]
   (try

--- a/src/eastwood/linters/typos.clj
+++ b/src/eastwood/linters/typos.clj
@@ -959,7 +959,7 @@ warning, that contains the constant value."
                          (count matching-assert-asts)
                          (pr-str condition-form)))))))
 
-(defn wrong-pre-post-messages [kind conditions method-num ast
+(defn wrong-pre-post-messages [opt kind conditions method-num ast
                                condition-desc-begin condition-desc-middle]
 ;;  (println (format "dbg wrong-pre-post-messages: kind=%s method-num=%s conditions=%s (vector? conditions)=%s (class conditions)=%s"
 ;;                   kind method-num conditions
@@ -1005,9 +1005,10 @@ warning, that contains the constant value."
                 nil
 
                 :else
-                (println (format "dbg wrong-pre-post: condition=%s line=%d test-ast :op=%s"
-                                 condition (:line (meta conditions))
-                                 (:op test-ast))))))))
+                (when (util/debug? :forms opt)
+                  (println (format "dbg wrong-pre-post: condition=%s line=%d test-ast :op=%s"
+                                   condition (:line (meta conditions))
+                                   (:op test-ast)))))))))
 ;;)
 
 (defn wrong-pre-post [{:keys [asts]} opt]
@@ -1018,7 +1019,8 @@ warning, that contains the constant value."
      (for [{:keys [ast form name pre method-num]} fns-with-pre-post
            :when pre
            :let [loc (meta pre)
-                 msgs (wrong-pre-post-messages :precondition pre
+                 msgs (wrong-pre-post-messages opt
+                                               :precondition pre
                                                method-num ast
                                                "Precondition"
                                                "preconditions")]
@@ -1030,7 +1032,8 @@ warning, that contains the constant value."
      (for [{:keys [ast form name post method-num]} fns-with-pre-post
            :when post
            :let [loc (meta post)
-                 msgs (wrong-pre-post-messages :postcondition post
+                 msgs (wrong-pre-post-messages opt
+                                               :postcondition post
                                                method-num ast
                                                "Postcondition"
                                                "postconditions")]

--- a/test-resources/eastwood/config/disable_wrong_tag.clj
+++ b/test-resources/eastwood/config/disable_wrong_tag.clj
@@ -1,0 +1,4 @@
+(disable-warning
+ {:linter :wrong-tag
+  :if-inside-macroexpansion-of '#{testcases.wrong-tag-example/the-macro}
+  :reason "Support a deftest"})

--- a/test-third-party-deps/eastwood/third_party_deps_test.clj
+++ b/test-third-party-deps/eastwood/third_party_deps_test.clj
@@ -1,0 +1,9 @@
+(ns eastwood.third-party-deps-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [eastwood.lint]))
+
+(deftest speced-def-handling
+  (testing "Is able to process usages of the `nedap.speced.def` library without false positives"
+    (is (= {:some-warnings false}
+           (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.speced-def-example}))))))

--- a/test-third-party-deps/testcases/speced_def_example.clj
+++ b/test-third-party-deps/testcases/speced_def_example.clj
@@ -1,0 +1,169 @@
+(ns testcases.speced-def-example
+  "Exercises the `speced.def` library"
+  (:require
+   [clojure.spec.alpha :as spec]
+   [nedap.speced.def :as speced]
+   [clojure.string :as string]))
+
+(spec/def ::foo int?)
+
+(speced/defn ^pos? foo []
+  1)
+
+(speced/defn ^string? foo2 []
+  "")
+
+(speced/defn bar [^pos? x]
+  x)
+
+(speced/defn bar2 [^string? x]
+  x)
+
+(speced/defn baz [{:keys [^pos? x]}]
+  x)
+
+(speced/defn baz2 [{:keys [^string? x]}]
+  x)
+
+(speced/defn ^String string1 []
+  "")
+
+(speced/defn string2 ^String []
+  "")
+
+(speced/defn string3 [{:keys [^String a]}]
+  "")
+
+(speced/defn ^::foo kw1 [])
+
+(speced/defn kw2 [^::foo x])
+
+(speced/defn kw3 [{:keys [^::foo x]}])
+
+(speced/defprotocol Prot
+  ""
+  (^::foo method1 [this] "")
+  (^String method2 [this] "")
+  (^pos? method3 [this] "")
+  (^string? method4 [this] "")
+  (method5 [this ^::foo x] "")
+  (method6 [this ^String x] "")
+  (method7 [this ^pos? x] "")
+  (method8 [this ^string? x] ""))
+
+(defn uses-letfn []
+  (speced/letfn [(^pos? inner-foo []
+                  1)
+
+                 (inner-bar [^pos? x]
+                   x)
+
+                 (inner-baz [{:keys [^pos? x]}]
+                   x)
+
+                 (inner-bar2 [^string? x]
+                   x)
+
+                 (inner-baz2 [{:keys [^string? x]}]
+                   x)
+
+                 (^String inner-string1 []
+                  "")
+
+                 (inner-string2 ^String []
+                   "")
+
+                 (inner-string3 [{:keys [^String a]}]
+                   "")
+
+                 (^::foo inner-kw1 [])
+
+                 (inner-kw2 [^::foo x])
+
+                 (inner-kw3 [{:keys [^::foo x]}])]
+    42))
+
+(defn uses-fn []
+  (let [inner-foo (speced/fn ^pos? []
+                    1)
+
+        inner-bar (speced/fn [^pos? x]
+                    x)
+
+        inner-baz (speced/fn [{:keys [^pos? x]}]
+                    x)
+
+        inner-foo2 (speced/fn ^string? []
+                     1)
+
+        inner-bar2 (speced/fn [^string? x]
+                     x)
+
+        inner-baz2 (speced/fn [{:keys [^string? x]}]
+                     x)
+
+        inner-string1 (speced/fn ^String []
+                        "")
+
+        inner-string2 (speced/fn ^String []
+                        "")
+
+        inner-string3 (speced/fn [{:keys [^String a]}]
+                        "")
+
+        inner-kw1 (speced/fn ^::foo [])
+
+        inner-kw2 (speced/fn [^::foo x])
+
+        inner-kw3 (speced/fn [{:keys [^::foo x]}])]
+    42))
+
+(defn uses-let []
+  (speced/let [^pos? a               1
+               ^string? aa           ""
+               ^::foo b              1
+               ^String c             ""
+               {:keys [^pos? d]}     {:d 1}
+               {:keys [^string? dd]} {:dd ""}
+               {:keys [^::foo e]}    {:e 1}
+               {:keys [^String f]}   {:f ""}]
+    [a b c d e]))
+
+;; a real-world example
+(speced/defn ^::speced/nilable ^set? extract-refers [libspec]
+  (let [libspec (vec libspec)
+        index (some->> libspec
+                       (keep-indexed (fn [i x]
+                                       (when (#{:refer} x)
+                                         i)))
+                       (first)
+                       (inc))
+        refers (when index
+                 (get libspec index))]
+    (when (coll? refers)
+      (set refers))))
+
+;; another real-world example
+(speced/defn ^boolean? contains-dynamic-assertions?
+  [{{{ast-form :form} :ast} :wrong-pre-post
+    msg                     :msg}]
+  (let [[_fn* fn-tails] (if (coll? ast-form)
+                          ast-form
+                          [])
+        [_arglist & body] (if (coll? fn-tails)
+                            fn-tails
+                            [])]
+    (->> body
+         (some (fn [form]
+                 (when (and (coll? form)
+                            (= 'clojure.core/assert
+                               (first form)))
+                   (let [v      (second form)
+                         v-name (when (symbol? v)
+                                  (name v))]
+                     (and v-name
+                          (string/includes? msg v-name)
+                          (= \*
+                             (first v-name)
+                             (last v-name)))))))
+         (boolean))))

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -153,8 +153,8 @@ The ignored-faults must match ns (exactly) and file/column (exactly, but only if
                                  (assoc :namespaces #{'testcases.ignored-faults-example}
                                         :ignored-faults input)
                                  (eastwood.lint/eastwood)))
-      {}                                                                                {:some-warnings true}
-      {:implicit-dependencies {'testcases.ignored-faults-example true}}                 {:some-warnings false}
+      {}                                                                                  {:some-warnings true}
+      {:implicit-dependencies {'testcases.ignored-faults-example true}}                   {:some-warnings false}
       {:implicit-dependencies {'testcases.ignored-faults-example [{:line 4 :column 1}]}}  {:some-warnings false}
       {:implicit-dependencies {'testcases.ignored-faults-example [{:line 4 :column 99}]}} {:some-warnings true}
       {:implicit-dependencies {'testcases.ignored-faults-example [{:line 99 :column 1}]}} {:some-warnings true})))
@@ -168,3 +168,15 @@ The ignored-faults must match ns (exactly) and file/column (exactly, but only if
   (testing "Processing a vanilla defn where `^:test` is used results in no linter faults"
     (is (= {:some-warnings false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.test-metadata-example}))))))
+
+(deftest wrong-tag-disabling-test
+  (testing "The `:wrong-tag` linter can be selectively disabled via the `disable-warning` mechanism,
+relative to a specific macroexpansion"
+    (are [input expected] (= expected
+                             (-> eastwood.lint/default-opts
+                                 (assoc :namespaces #{'testcases.wrong-tag-example})
+                                 (merge input)
+                                 eastwood.lint/eastwood))
+      {}                                                          {:some-warnings true}
+      {:builtin-config-files ["disable_wrong_tag.clj"]}           {:some-warnings false}
+      {:builtin-config-files ["disable_wrong_tag_unrelated.clj"]} {:some-warnings true})))


### PR DESCRIPTION
Supports the [speced.def](https://github.com/nedap/speced.def) library and also might be useful for other purposes.

Relatedly, now this third-party lib is exercised in CI, in an isolated job matrix. This way we can run foreign code resting assured that the presence of these libs doesn't affect the results of the main test suite.

This new matrix opens the door to exercising more third-party code e.g. core.async.

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
