### PR TITLE
`eastwood.lint/eastwood`: offer `:some-errors` key

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -8,6 +8,8 @@
   * Related: the `disable-warnings` that Eastwood ships by default now prevent false positives against the [speced.def](https://github.com/nedap/speced.def) lib. 
 * Now the `:suspicious-test` linter can also be configured via the [`disable-warning`](https://github.com/jonase/eastwood#eastwood-config-files) mechanism.
   * Relatedly, a certain pattern of usage of the `clojure.test/are` macro now does not trigger a linter fault. 
+* If you invoke `eastwood.lint/eastwood` programatically, now a new key is offered: `:some-errors`, akin to `:some-warnings`.
+  * This allows to distinguish why did Eastwood fail.
 
 #### Bugfixes
 

--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -523,8 +523,10 @@ Return value:
   (reporting/note reporter (format "== Warnings: %d (not including reflection warnings)  Exceptions thrown: %d"
                                    warning-count
                                    error-count))
-  {:some-warnings (or (> warning-count 0)
-                      (> error-count 0))})
+  (let [has-errors? (> error-count 0)]
+    {:some-warnings (or (> warning-count 0)
+                        has-errors?)
+     :some-errors has-errors?}))
 
 (defn eastwood
   ([opts] (eastwood opts (reporting/printing-reporter opts)))
@@ -554,7 +556,8 @@ Return value:
        (reporting/show-error reporter (or (ex-data e) e))
        (if rethrow-exceptions?
          (throw e)
-         {:some-warnings true})))))
+         {:some-warnings true
+          :some-errors true})))))
 
 (defn eastwood-from-cmdline [opts]
   (let [ret (eastwood opts)]

--- a/test-resources/eastwood/config/disable_wrong_tag_unrelated.clj
+++ b/test-resources/eastwood/config/disable_wrong_tag_unrelated.clj
@@ -1,0 +1,4 @@
+(disable-warning
+ {:linter :wrong-tag
+  :if-inside-macroexpansion-of '#{unrelated.ns/another-macro}
+  :reason "Support a deftest"})

--- a/test-third-party-deps/eastwood/third_party_deps_test.clj
+++ b/test-third-party-deps/eastwood/third_party_deps_test.clj
@@ -5,5 +5,5 @@
 
 (deftest speced-def-handling
   (testing "Is able to process usages of the `nedap.speced.def` library without false positives"
-    (is (= {:some-warnings false}
+    (is (= {:some-warnings false :some-errors false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.speced-def-example}))))))

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -99,7 +99,8 @@
 
 (deftest large-defprotocol-test
   (testing "A large defprotocol doesn't cause a 'Method code too large' exception"
-    (is (= {:some-warnings false}
+    (is (= {:some-warnings false
+            :some-errors false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.large-defprotocol}))))))
 
 (deftest ignore-fault?-test
@@ -151,7 +152,7 @@
 (deftest ignored-faults-test
   (testing "A ignored-faults can remove warnings.
 The ignored-faults must match ns (exactly) and file/column (exactly, but only if provided)"
-    (are [input expected] (= expected
+    (are [input expected] (= (assoc expected :some-errors false)
                              (-> eastwood.lint/default-opts
                                  (assoc :namespaces #{'testcases.ignored-faults-example}
                                         :ignored-faults input)
@@ -164,18 +165,20 @@ The ignored-faults must match ns (exactly) and file/column (exactly, but only if
 
 (deftest const-handling
   (testing "Processing a namespace where `^:const` is used results in no exceptions being thrown"
-    (is (= {:some-warnings false}
+    (is (= {:some-warnings false
+            :some-errors false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.const}))))))
 
 (deftest test-metadata-handling
   (testing "Processing a vanilla defn where `^:test` is used results in no linter faults"
-    (is (= {:some-warnings false}
+    (is (= {:some-warnings false
+            :some-errors false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.test-metadata-example}))))))
 
 (deftest wrong-tag-disabling-test
   (testing "The `:wrong-tag` linter can be selectively disabled via the `disable-warning` mechanism,
 relative to a specific macroexpansion"
-    (are [input expected] (= expected
+    (are [input expected] (= (assoc expected :some-errors false)
                              (-> eastwood.lint/default-opts
                                  (assoc :namespaces #{'testcases.wrong-tag-example})
                                  (merge input)
@@ -186,7 +189,7 @@ relative to a specific macroexpansion"
 
 (deftest are-true-test
   (are [desc input expected] (testing input
-                               (is (= expected
+                               (is (= (assoc expected :some-errors false)
                                       (-> eastwood.lint/default-opts
                                           (assoc :namespaces input)
                                           (eastwood.lint/eastwood)))
@@ -206,5 +209,6 @@ relative to a specific macroexpansion"
 
 (deftest clojure-test-test
   (testing "Some reported false positives against clojure.test"
-    (is (= {:some-warnings false}
+    (is (= {:some-warnings false
+            :some-errors false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.clojure-test}))))))


### PR DESCRIPTION
It's akin to `:some-warnings`, but informs exclusively about exceptions.

This strengthens our tests, which relatedly, were missing a file under the `resource/` dir (thankfully, without impact).

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
