### PR TITLE
[Fix #303] Make the `:unused-meta-on-macro` linter omittable

### DIFF
--- a/cases/testcases/wrong_meta_on_macro_example.clj
+++ b/cases/testcases/wrong_meta_on_macro_example.clj
@@ -1,0 +1,4 @@
+(ns testcases.wrong-meta-on-macro-example)
+
+(.toString ^String (let [v ""]
+                     v))

--- a/changes.md
+++ b/changes.md
@@ -8,6 +8,8 @@
   * Related: the `disable-warnings` that Eastwood ships by default now prevent false positives against the [speced.def](https://github.com/nedap/speced.def) lib. 
 * Now the `:suspicious-test` linter can also be configured via the [`disable-warning`](https://github.com/jonase/eastwood#eastwood-config-files) mechanism.
   * Relatedly, a certain pattern of usage of the `clojure.test/are` macro now does not trigger a linter fault. 
+* Now the `:unused-meta-on-macro` linter can also be configured via the [`disable-warning`](https://github.com/jonase/eastwood#eastwood-config-files) mechanism.
+  * Closes https://github.com/jonase/eastwood/issues/303
 * If you invoke `eastwood.lint/eastwood` programatically, now a new key is offered: `:some-errors`, akin to `:some-warnings`.
   * This allows to distinguish why did Eastwood fail.
 

--- a/src/eastwood/linters/unused.clj
+++ b/src/eastwood/linters/unused.clj
@@ -624,58 +624,62 @@ discarded inside null: null'."
                            (mapcat ast/nodes)
                            (filter #(and (:raw-forms %)
                                          (-> % :raw-forms first meta))))]
-    (for [ast macro-invokes
-          :let [orig-form (-> ast :raw-forms first)
-                loc (-> orig-form meta)
-                ;; The ::resolved-op key was added recently to t.a(.j)
-                ;; libs to record the resolution of Var names in
-                ;; :raw-forms.
-                non-loc-meta-keys (-> (set (keys loc))
-                                      (set/difference #{:file :line :column
-                                                        :end-line :end-column
-                                                        :eastwood.copieddeps.dep1.clojure.tools.analyzer/resolved-op}))
-                resolved-macro-symbol (-> ast :raw-forms first
-                                          util/fqsym-of-raw-form)
-                removed-meta-keys
-                (cond (= :new (:op ast)) non-loc-meta-keys
+    (->> (for [ast macro-invokes
+               :let [orig-form (-> ast :raw-forms first)
+                     loc (-> orig-form meta)
+                     ;; The ::resolved-op key was added recently to t.a(.j)
+                     ;; libs to record the resolution of Var names in
+                     ;; :raw-forms.
+                     non-loc-meta-keys (-> (set (keys loc))
+                                           (set/difference #{:file :line :column
+                                                             :end-line :end-column
+                                                             :eastwood.copieddeps.dep1.clojure.tools.analyzer/resolved-op}))
+                     resolved-macro-symbol (-> ast :raw-forms first
+                                               util/fqsym-of-raw-form)
+                     removed-meta-keys
+                     (cond (= :new (:op ast)) non-loc-meta-keys
 
-                      (#{:instance-call :static-call
-                         :instance-field :static-field :host-interop} (:op ast))
-                      (disj non-loc-meta-keys :tag)
+                           (#{:instance-call :static-call
+                              :instance-field :static-field :host-interop} (:op ast))
+                           (disj non-loc-meta-keys :tag)
 
-                      ;; No metadata is removed for invocations of
-                      ;; clojure.core/fn -- It is implemented
-                      ;; specially to do this by examining the
-                      ;; metadata of its &form argument.
-                      (= resolved-macro-symbol 'clojure.core/fn) []
+                           ;; No metadata is removed for invocations of
+                           ;; clojure.core/fn -- It is implemented
+                           ;; specially to do this by examining the
+                           ;; metadata of its &form argument.
+                           (= resolved-macro-symbol 'clojure.core/fn) []
 
-                      :else non-loc-meta-keys)
+                           :else non-loc-meta-keys)
 
-                sorted-removed-meta-keys (sort removed-meta-keys)]
-          :when (seq removed-meta-keys)]
+                     sorted-removed-meta-keys (sort removed-meta-keys)]
+               :when (seq removed-meta-keys)
+               :let [warning {:loc loc
+                              :linter :unused-meta-on-macro
+                              :unused-meta-on-macro {:ast ast}
+                              :msg
+                              (cond
+                                (= :new (:op ast))
+                                (format "Java constructor call '%s' has metadata with keys %s.  All metadata is eliminated from such forms during macroexpansion and thus ignored by Clojure."
+                                        (first orig-form)
+                                        sorted-removed-meta-keys)
 
-      {:loc loc
-       :linter :unused-meta-on-macro
-       :msg
-       (cond
-         (= :new (:op ast))
-         (format "Java constructor call '%s' has metadata with keys %s.  All metadata is eliminated from such forms during macroexpansion and thus ignored by Clojure."
-                 (first orig-form)
-                 sorted-removed-meta-keys)
+                                (#{:instance-call :static-call :instance-field :static-field
+                                   :host-interop} (:op ast))
+                                (format "Java %s '%s' has metadata with keys %s.  All metadata keys except :tag are eliminated from such forms during macroexpansion and thus ignored by Clojure."
+                                        (case (:op ast)
+                                          :instance-call "instance method call"
+                                          :static-call "static method call"
+                                          :instance-field "instance field access"
+                                          :static-field "static field access"
+                                          :host-interop "instance method/field access")
+                                        (first orig-form)
+                                        sorted-removed-meta-keys)
 
-         (#{:instance-call :static-call :instance-field :static-field
-            :host-interop} (:op ast))
-         (format "Java %s '%s' has metadata with keys %s.  All metadata keys except :tag are eliminated from such forms during macroexpansion and thus ignored by Clojure."
-                 (case (:op ast)
-                   :instance-call "instance method call"
-                   :static-call "static method call"
-                   :instance-field "instance field access"
-                   :static-field "static field access"
-                   :host-interop "instance method/field access")
-                 (first orig-form)
-                 sorted-removed-meta-keys)
+                                :else
+                                (format "Macro invocation of '%s' has metadata with keys %s that are almost certainly ignored."
+                                        (first orig-form)
+                                        sorted-removed-meta-keys))}]
+               :when (util/allow-warning warning opt)]
+           warning)
 
-         :else
-         (format "Macro invocation of '%s' has metadata with keys %s that are almost certainly ignored."
-                 (first orig-form)
-                 sorted-removed-meta-keys))})))
+         (filter identity))))

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -939,6 +939,7 @@ StringWriter."
             (case linter
               (:constant-test :redefd-vars :unused-ret-vals
                               :wrong-tag :suspicious-test
+                              :unused-meta-on-macro
                               :unused-ret-vals-in-try)
               (update-in configs [linter]
                          conj (dissoc m :linter))
@@ -1037,7 +1038,7 @@ StringWriter."
            w linter (format " for invocation of macro '%s'" macro-symbol)
            suppress-conditions opt)))
 
-      (:unused-ret-vals :unused-ret-vals-in-try :constant-test :wrong-tag :suspicious-test)
+      (:unused-ret-vals :unused-ret-vals-in-try :constant-test :wrong-tag :suspicious-test :unused-meta-on-macro)
       (let [suppress-conditions (get-in opt [:warning-enable-config linter])]
         (allow-warning-based-on-enclosing-macros
          w linter "" suppress-conditions opt)))))

--- a/test-resources/eastwood/config/disable_unused_meta_on_macro.clj
+++ b/test-resources/eastwood/config/disable_unused_meta_on_macro.clj
@@ -1,0 +1,4 @@
+(disable-warning
+ {:linter :unused-meta-on-macro
+  :if-inside-macroexpansion-of '#{clojure.core/let}
+  :reason "Support a deftest"})

--- a/test-resources/eastwood/config/disable_unused_meta_on_macro_unrelated.clj
+++ b/test-resources/eastwood/config/disable_unused_meta_on_macro_unrelated.clj
@@ -1,0 +1,4 @@
+(disable-warning
+ {:linter :unused-meta-on-macro
+  :if-inside-macroexpansion-of '#{unrelated.ns/let}
+  :reason "Support a deftest"})

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -187,6 +187,18 @@ relative to a specific macroexpansion"
       {:builtin-config-files ["disable_wrong_tag.clj"]}           {:some-warnings false}
       {:builtin-config-files ["disable_wrong_tag_unrelated.clj"]} {:some-warnings true})))
 
+(deftest unused-meta-on-macro-disabling-test
+  (testing "The `:unused-meta-on-macro` linter can be selectively disabled via the `disable-warning` mechanism,
+relative to a specific macroexpansion"
+    (are [input expected] (= (assoc expected :some-errors false)
+                             (-> eastwood.lint/default-opts
+                                 (assoc :namespaces #{'testcases.wrong-meta-on-macro-example})
+                                 (merge input)
+                                 eastwood.lint/eastwood))
+      {}                                                                     {:some-warnings true}
+      {:builtin-config-files ["disable_unused_meta_on_macro.clj"]}           {:some-warnings false}
+      {:builtin-config-files ["disable_unused_meta_on_macro_unrelated.clj"]} {:some-warnings true})))
+
 (deftest are-true-test
   (are [desc input expected] (testing input
                                (is (= (assoc expected :some-errors false)


### PR DESCRIPTION
Fixes https://github.com/jonase/eastwood/issues/303

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
