### PR TITLE
Test suite improvements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,9 @@
                                      "cases"]
                     :jvm-opts ["-Deastwood.internal.running-test-suite=true"]}
              :test-3rd-party-deps {:test-paths ^:replace ["test-third-party-deps"]
-                                   :dependencies [[com.nedap.staffing-solutions/speced.def "2.0.0"]]}
+                                   :dependencies [[com.nedap.staffing-solutions/speced.def "2.0.0"]
+                                                  [com.taoensso/timbre "5.1.2"]
+                                                  [com.taoensso/tufte "2.2.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,8 @@
                  [org.ow2.asm/asm-all "5.2"]]
   :profiles {:dev {:dependencies [[org.clojure/tools.macro "0.1.5"]
                                   [jafingerhut/dolly "0.1.0"]]}
-             :eastwood-plugin {:source-paths [~plugin-source-path]}
+             :eastwood-plugin {:source-paths [~plugin-source-path]
+                               :jvm-opts ["-Deastwood.internal.plugin-profile-active=true"]}
              :warn-on-reflection {:global-vars {*warn-on-reflection* true}}
              :test {:dependencies
                     ;; NOTE: please don't add non-essential 3rd-party deps here.
@@ -25,7 +26,8 @@
                     :resource-paths ["test-resources"
                                      ;; if wanting the `cases` to be available during development / the default profile,
                                      ;; please simply add `with-profile +test` to your CLI invocation.
-                                     "cases"]}
+                                     "cases"]
+                    :jvm-opts ["-Deastwood.internal.running-test-suite=true"]}
              :test-3rd-party-deps {:test-paths ^:replace ["test-third-party-deps"]
                                    :dependencies [[com.nedap.staffing-solutions/speced.def "2.0.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/src/eastwood/util.clj
+++ b/src/eastwood/util.clj
@@ -969,8 +969,11 @@ StringWriter."
         (binding [*ns* (the-ns 'eastwood.util)]
           (load-reader (io/reader config-file)))
         (catch Exception e
-          (println (format "Exception while attempting to load config file: %s" config-file))
-          (pst e nil))))
+          (if (= "true" (System/getProperty "eastwood.internal.running-test-suite"))
+            (throw e)
+            (do
+              (println (format "Exception while attempting to load config file: %s" config-file))
+              (pst e nil))))))
     (process-configs @warning-enable-config-atom)))
 
 (defn meets-suppress-condition [ast enclosing-macros qualifier condition]

--- a/test-third-party-deps/eastwood/third_party_deps_test.clj
+++ b/test-third-party-deps/eastwood/third_party_deps_test.clj
@@ -7,3 +7,13 @@
   (testing "Is able to process usages of the `nedap.speced.def` library without false positives"
     (is (= {:some-warnings false :some-errors false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.speced-def-example}))))))
+
+(deftest timbre-example
+  (testing "Is able to process usages of the `taoensso.timbre` library without false positives"
+    (is (= {:some-warnings false :some-errors false}
+           (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.timbre-example}))))))
+
+(deftest tufte-example
+  (testing "Is able to process usages of the `taoensso.tufte` library without false positives"
+    (is (= {:some-warnings false :some-errors false}
+           (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.tufte-example}))))))

--- a/test-third-party-deps/testcases/timbre_example.clj
+++ b/test-third-party-deps/testcases/timbre_example.clj
@@ -1,0 +1,13 @@
+(ns testcases.timbre-example
+  (:require [taoensso.timbre :as log]))
+
+(defn uses-logging []
+  (log/error 42)
+  (log/warn 42)
+  (log/info 42)
+  (log/debug 42)
+
+  (log/errorf "%s" 42)
+  (log/warnf "%s" 42)
+  (log/infof "%s" 42)
+  (log/debugf "%s" 42))

--- a/test-third-party-deps/testcases/tufte_example.clj
+++ b/test-third-party-deps/testcases/tufte_example.clj
@@ -1,0 +1,21 @@
+(ns testcases.tufte-example
+  (:require [taoensso.tufte :refer [defnp p profiled profile]]))
+
+;; https://github.com/jonase/eastwood/issues/161
+(defnp my-fun
+  []
+  (+ 1 1))
+
+;; https://github.com/ptaoussanis/tufte/tree/396ca0d5e05db9d9721635ca11bf4e00fb393ab8#10-second-example
+
+;;; Let's define a couple dummy fns to simulate doing some expensive work
+(defn get-x [] (Thread/sleep 500)             "x val")
+(defn get-y [] (Thread/sleep (rand-int 1000)) "y val")
+
+;; How do these fns perform? Let's check:
+
+(profile         ; Profile any `p` forms called during body execution
+ {}              ; Profiling options; we'll use the defaults for now
+ (dotimes [_ 5]
+   (p :get-x (get-x))
+   (p :get-y (get-y))))

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -10,6 +10,13 @@
   (:import
    (java.io File)))
 
+(when-not (System/getProperty "eastwood.internal.plugin-profile-active")
+  (let [p "eastwood.internal.running-test-suite"
+        v (System/getProperty p)]
+    (assert (= "true" v)
+            (format "The test suite should be running with the %s system property set, for extra test robustness"
+                    p))))
+
 (deftest expand-ns-keywords-test
   (testing ""
     (is (= ["foo" "bar" "baz"] (expand-ns-keywords {:source-paths ["foo"]} [:source-paths "bar" "baz"])))))


### PR DESCRIPTION
> Closes https://github.com/jonase/eastwood/issues/161

2 commits:

#### Strengthen config reading in tests

Despite https://github.com/jonase/eastwood/pull/375, it was still possible to refer to non-existing config files in tests, simply because the configs are read in a try/catch that would swallow exceptions.

Now that section of the code rethrows exceptions _iff_ we are running the test suite.

#### Exercise Timbre and Tufte under the `:test-3rd-party-deps` suite

Nothing had to be fixed.

This addition simply proves that Eastwood can in fact handle said libs.

Interestingly it also exercises tools.analyzer more by giving it some extra real-world libs to run in CI.

- [ ] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
