### PR TITLE
Remove some `println`s

### DIFF
--- a/src/eastwood/linters/typetags.clj
+++ b/src/eastwood/linters/typetags.clj
@@ -117,18 +117,11 @@ significance needed by the user."
 
                                    :else
                                    (do
-                                     ;; Use this to help detect wrong-tag cases I may
-                                     ;; be missing completely.
-                                     (println (format "eastwood-dbg: wrong-tag-from-analyzer: op=%s name=%s wrong-tag-keys=%s env=%s ast="
-                                                      op name wrong-tag-keys env))
                                      (util/pprint-ast-node ast)
                                      (flush)
                                      (assert false)
                                      [nil nil nil]))
                              _ (when (and typ (not (util/has-keys? loc #{:file :line :column})))
-                                 (println (format "eastwood-dbg: wrong-tag-no-loc: op=%s name=%s wrong-tag-keys=%s typ=%s tag=%s loc=%s ast="
-                                                  op name wrong-tag-keys
-                                                  typ tag loc))
                                  (util/pprint-ast-node ast))
                              ;;              _ (do
                              ;;                  (println (format "jafinger-dbg2: typ=%s tag=%s loc=%s"

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -1,6 +1,5 @@
 (ns eastwood.lint-test
   (:require
-   [clojure.string :as string]
    [clojure.test :refer :all]
    [eastwood.copieddeps.dep11.clojure.java.classpath :as classpath]
    [eastwood.copieddeps.dep9.clojure.tools.namespace.dir :as dir]
@@ -97,9 +96,9 @@
              (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces invalid-namespaces)))))
 
     (testing "Reader-level exceptions are reported as such"
-      (is (string/includes? (with-out-str
-                              (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces invalid-namespaces)))
-                            "Warnings: 0 (not including reflection warnings)  Exceptions thrown: 1")))
+      (is (-> (with-out-str
+                (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces invalid-namespaces)))
+              (.contains "Warnings: 0 (not including reflection warnings)  Exceptions thrown: 1"))))
 
     (testing "`:rethrow-exceptions?` option"
       (are [namespaces rethrow-exceptions? ok?] (testing [namespaces rethrow-exceptions?]


### PR DESCRIPTION
#### Remove some printlns

On certain inputs, they would try applying `pr-str` over a huge (or infiinite - I don't know) object and OOM accordingly.

I'd be inclined to remove the println and simply let users report issues.

A `println` can be dangerous otherwise and most users typically cannot make much use of it anyway.

#### Avoid `string/includes?`

Would break the clojure 1.7 job.

- [ ] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
