### PR TITLE
[Fix #383] Fix a false positive in `let` destructuring

### DIFF
--- a/cases/testcases/let/green.clj
+++ b/cases/testcases/let/green.clj
@@ -1,0 +1,8 @@
+(ns testcases.let.green)
+
+;; https://github.com/jonase/eastwood/issues/383
+(defn ok []
+  (let [{:keys [x]
+         :as y}
+        {:x 9}]
+    1))

--- a/cases/testcases/let/red.clj
+++ b/cases/testcases/let/red.clj
@@ -1,0 +1,7 @@
+(ns testcases.let.red)
+
+(defn faulty []
+  (let [a (if (seq? {})
+            1
+            2)]
+    a))

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,12 @@
 # Change log for Eastwood
 
+## Changes from 0.4.1 to
+
+#### Bugfixes
+
+* Fix a false positive for `let` destructuring
+  * Closes https://github.com/jonase/eastwood/issues/383
+
 ## Changes from 0.4.0 to 0.4.1
 
 #### New

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -249,3 +249,14 @@ relative to a specific macroexpansion"
     (is (= {:some-warnings false
             :some-errors false}
            (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.clojure-test}))))))
+
+(deftest let-test
+  (testing "Some reported false positives against `let`"
+    (are [input expected] (testing input
+                            (is (= (assoc expected :some-errors false)
+                                   (-> eastwood.lint/default-opts
+                                       (assoc :namespaces input)
+                                       (eastwood.lint/eastwood))))
+                            true)
+      #{'testcases.let.green} {:some-warnings false}
+      #{'testcases.let.red}   {:some-warnings true})))

--- a/test/eastwood/linters/typos_test.clj
+++ b/test/eastwood/linters/typos_test.clj
@@ -1,0 +1,31 @@
+(ns eastwood.linters.typos-test
+  (:require
+   [clojure.test :refer [are deftest is join-fixtures testing use-fixtures]]
+   [eastwood.linters.typos :as sut]))
+
+(deftest seq-call-from-destructuring?
+  (testing "Detects a very specific call, for preventing false positives/negatives"
+    (are [desc input expected] (testing input
+                                 (is (= expected
+                                        (sut/seq-call-from-destructuring? input))
+                                     desc)
+                                 true)
+      "Only the targeted shape returns `true`"
+      '(if (clojure.core/seq? map__413572) (clojure.lang.PersistentHashMap/create (clojure.core/seq map__413572)) map__413572)
+      true
+
+      "Placing an unexpected `seq?`"
+      '(if (clojure.core/seq? map__413572) (clojure.lang.PersistentHashMap/create (clojure.core/seq? map__413572)) map__413572)
+      false
+
+      "Placing an unexpected `sequential?`"
+      '(if (clojure.core/sequential? map__413572) (clojure.lang.PersistentHashMap/create (clojure.core/seq map__413572)) map__413572)
+      false
+
+      "Using a naming other than `map__`"
+      '(if (clojure.core/seq? mOp__413572) (clojure.lang.PersistentHashMap/create (clojure.core/seq map__413572)) map__413572)
+      false
+
+      "Using a naming other than `map__`"
+      '(if (clojure.core/seq? map__413572) (clojure.lang.PersistentHashMap/create (clojure.core/seq map__413572)) m0p__413572)
+      false)))


### PR DESCRIPTION
Closes #383

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
