### PR TITLE
[Fix #169] Prove that various cond, cond-> forms work correctly

### DIFF
--- a/cases/testcases/cond/green.clj
+++ b/cases/testcases/cond/green.clj
@@ -1,0 +1,22 @@
+(ns testcases.cond.green)
+
+(defn foo []
+  ;; https://github.com/jonase/eastwood/issues/169
+  (cond-> {}
+    true (assoc 1 1))
+
+  (cond
+    (< (rand) 0.5)
+    1
+
+    ;; https://github.com/jonase/eastwood/issues/169#issuecomment-328940985
+    true
+    false)
+
+  (cond
+    (< (rand) 0.5)
+    1
+
+    ;; https://github.com/jonase/eastwood/issues/169#issuecomment-144686370
+    :default
+    false))

--- a/resource/eastwood/config/clojure.clj
+++ b/resource/eastwood/config/clojure.clj
@@ -60,8 +60,9 @@
 (disable-warning
  {:linter :constant-test
   :if-inside-macroexpansion-of #{'clojure.core/cond-> 'clojure.core/cond->>}
+  :qualifier true
   :within-depth 2
-  :reason "Allow cond-> and cond->> to have constant tests without warning"})
+  :reason "Allow cond-> and cond->> to have constant tests without warning, only for the `true` condition"})
 
 (disable-warning
   {:linter :constant-test

--- a/src/eastwood/linters/typos.clj
+++ b/src/eastwood/linters/typos.clj
@@ -884,6 +884,7 @@ warning, that contains the constant value."
                         (pass/code-loc (pass/nearest-ast-with-loc ast)))
                 w {:loc loc
                    :linter :constant-test
+                   :qualifier (-> ast :form second)
                    :constant-test {:kind :the-only-kind
                                    :ast ast}
                    :msg (format "Test expression is always logical true or always logical false: %s in form %s"

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -260,3 +260,15 @@ relative to a specific macroexpansion"
                             true)
       #{'testcases.let.green} {:some-warnings false}
       #{'testcases.let.red}   {:some-warnings true})))
+
+(deftest cond-test
+  (testing "Some reported false positives against `cond`"
+    (are [input expected] (testing input
+                            (is (= (assoc expected :some-errors false)
+                                   (-> eastwood.lint/default-opts
+                                       (assoc :namespaces input)
+                                       (eastwood.lint/eastwood))))
+                            true)
+      #{'testcases.cond.green} {:some-warnings false}
+      ;; some 'red' cases could be added at some point, there are no reported issues atm though.
+      )))


### PR DESCRIPTION
> Closes #169

This commit does two things:

* Prove that the three bugs described in #169 are fixed
  * (have been for a long time)
* Add and support a `:qualifier` value for `:constant-test`, so that only `true` will be accepted a `:constant-test` for `cond->`

- [ ] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
