### PR TITLE
[Fix #384] Support `is false` pattern

### DIFF
--- a/cases/testcases/is_false/green.clj
+++ b/cases/testcases/is_false/green.clj
@@ -1,0 +1,6 @@
+(ns testcases.is-false.green
+  (:require
+   [clojure.test :refer [are deftest is join-fixtures testing use-fixtures]]))
+
+(deftest foo
+  (is false))

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,11 @@
 
 ## Changes from 0.4.1 to
 
+#### New
+
+* Support `(is false)` pattern
+  * Closes https://github.com/jonase/eastwood/issues/384
+
 #### Bugfixes
 
 * Fix a false positive for `let` destructuring

--- a/resource/eastwood/config/clojure.clj
+++ b/resource/eastwood/config/clojure.clj
@@ -59,6 +59,13 @@
 
 (disable-warning
  {:linter :constant-test
+  :if-inside-macroexpansion-of #{'clojure.test/is}
+  :within-depth 3
+  :qualifier false
+  :reason "Support (is false) idiom https://github.com/jonase/eastwood/issues/384"})
+
+(disable-warning
+ {:linter :constant-test
   :if-inside-macroexpansion-of #{'clojure.core/cond-> 'clojure.core/cond->>}
   :qualifier true
   :within-depth 2

--- a/src/eastwood/linters/typos.clj
+++ b/src/eastwood/linters/typos.clj
@@ -884,7 +884,7 @@ warning, that contains the constant value."
                         (pass/code-loc (pass/nearest-ast-with-loc ast)))
                 w {:loc loc
                    :linter :constant-test
-                   :qualifier (-> ast :form second)
+                   :qualifier (-> constant-test-ast :form)
                    :constant-test {:kind :the-only-kind
                                    :ast ast}
                    :msg (format "Test expression is always logical true or always logical false: %s in form %s"

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -261,6 +261,18 @@ relative to a specific macroexpansion"
       #{'testcases.let.green} {:some-warnings false}
       #{'testcases.let.red}   {:some-warnings true})))
 
+(deftest is-false-test
+  (testing "The `(is false)` idiom is supported"
+    (are [input expected] (testing input
+                            (is (= (assoc expected :some-errors false)
+                                   (-> eastwood.lint/default-opts
+                                       (assoc :namespaces input)
+                                       (eastwood.lint/eastwood))))
+                            true)
+      #{'testcases.is-false.green} {:some-warnings false}
+      ;; no 'red' case for now, since there isn't one that would make sense today (given git.io/J35fr)
+      )))
+
 (deftest cond-test
   (testing "Some reported false positives against `cond`"
     (are [input expected] (testing input


### PR DESCRIPTION
Closes https://github.com/jonase/eastwood/issues/384

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
