### PR TITLE
[Fix #385] Support an edge case for `extend-protocol`

### DIFF
--- a/cases/testcases/bytes_class/green.clj
+++ b/cases/testcases/bytes_class/green.clj
@@ -1,0 +1,11 @@
+(ns testcases.bytes-class.green)
+
+(defprotocol ToBytes
+  (to-bytes [x]))
+
+(extend-protocol ToBytes
+  (Class/forName "[B")
+  (to-bytes [x] x))
+
+;; ensure that the construct in fact works (else we could be linting something that doesn't work in the first place):
+(assert (-> "" .getBytes to-bytes))

--- a/cases/testcases/wrongtag.clj
+++ b/cases/testcases/wrongtag.clj
@@ -198,14 +198,3 @@
   "Returns a copy of a double array"
   (^doubles [^doubles arr]
     (Arrays/copyOf arr (int (alength arr)))))
-
-
-(defprotocol PDoubleArrayOutput
-  (to-double-array [m])
-  (as-double-array [m]))
-
-
-(extend-protocol PDoubleArrayOutput
-  (Class/forName "[D")
-    (to-double-array [m] (copy-double-array m))
-    (as-double-array [m] m))

--- a/changes.md
+++ b/changes.md
@@ -11,6 +11,8 @@
 
 * Fix a false positive for `let` destructuring
   * Closes https://github.com/jonase/eastwood/issues/383
+* Fix a false positive for `extend-protocol`
+  * Closes https://github.com/jonase/eastwood/issues/385
 
 ## Changes from 0.4.0 to 0.4.1
 

--- a/src/eastwood/linters/typetags.clj
+++ b/src/eastwood/linters/typetags.clj
@@ -128,7 +128,12 @@ significance needed by the user."
                              ;;                                   typ tag loc))
                              ;;                  )
                              ]
-                       :when typ]
+                       :when (and typ
+                                  (if-not tag
+                                    true
+                                    (if-not (sequential? tag)
+                                      true
+                                      (not (-> tag first #{'Class/forName 'java.lang.Class/forName})))))]
                    (let [warning {:loc loc
                                   :linter :wrong-tag
                                   :wrong-tag {:ast ast}

--- a/test/eastwood/lint_test.clj
+++ b/test/eastwood/lint_test.clj
@@ -284,3 +284,8 @@ relative to a specific macroexpansion"
       #{'testcases.cond.green} {:some-warnings false}
       ;; some 'red' cases could be added at some point, there are no reported issues atm though.
       )))
+
+(deftest bytes-class-test
+  (testing "https://github.com/jonase/eastwood/issues/385"
+    (is (= {:some-warnings false :some-errors false}
+           (eastwood.lint/eastwood (assoc eastwood.lint/default-opts :namespaces #{'testcases.bytes-class.green}))))))

--- a/test/eastwood/test/linters_test.clj
+++ b/test/eastwood/test/linters_test.clj
@@ -1247,26 +1247,6 @@ the next."
           :msg "Wrong tag: (class (log-window-proxy nil)) on form: this",
           :file (fname-from-parts "testcases" "wrongtag.clj"),
           :line 153, :column 11}
-         1,
-         {:linter :wrong-tag,
-          :msg "Tag: (Class/forName \"[D\") for return type of function method: ([m] m) should be Java class name (fully qualified if not in java.lang package)",
-          :file (fname-from-parts "testcases" "wrongtag.clj"),
-          :line 208, :column 1}
-         1,
-         {:linter :wrong-tag,
-          :msg "Wrong tag: (Class/forName \"[D\") on form: (do m)",
-          :file (fname-from-parts "testcases" "wrongtag.clj"),
-          :line 208, :column 1}
-         1,
-         {:linter :wrong-tag,
-          :msg "Wrong tag: (Class/forName \"[D\") on form: m",
-          :file (fname-from-parts "testcases" "wrongtag.clj"),
-          :line 210, :column 23}
-         1,
-         {:linter :wrong-tag,
-          :msg "Wrong tag: (Class/forName \"[D\") on form: m",
-          :file (fname-from-parts "testcases" "wrongtag.clj"),
-          :line 211, :column 23}
          1}
 
         ;; These warnings are not needed after CLJ-1232 was fixed in


### PR DESCRIPTION
> Fixes https://github.com/jonase/eastwood/issues/385

This false positive's origin can be tracked down to this commit:

https://github.com/jonase/eastwood/commit/7c0f432ee1be4748fb6cb765089872cd7640d27e

I think that commit made the mistake of conflating "this pattern should not trigger an exception" with "with pattern should trigger a linter fault".

Usages in the wild such as the following show that in fact the pattern is functional:

* https://github.com/mikera/core.matrix/blob/0a35f6e3d6d2335cb56f6f3e5744bfa1dd0390aa/src/main/clojure/clojure/core/matrix/impl/double_array.clj#L124
* https://github.com/immutant/immutant/blob/6ff8fa03acf73929f61f2ca75446cb559ddfc1ef/web/src/immutant/web/async.clj#L198
* https://github.com/sunng87/ring-jetty9-adapter/blob/95bf989216cb01986615c40b4cc50178d1578db1/src/ring/adapter/jetty9/websocket.clj#L44
* https://github.com/funcool/catacumba/blob/a493843176ee8defa2f3c6afa23c720f495d9341/src/clojure/catacumba/impl/handlers.clj#L128

- [x] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)
