### PR TITLE
merge command line args

### DIFF
--- a/src/eastwood/lint.clj
+++ b/src/eastwood/lint.clj
@@ -1010,9 +1010,8 @@ Eastwood has other forms of effective, safe parallelism now. Falling back to seq
        -main))
 
   ([& opts]
-   (if (and
-        (= 1 (count opts))
-        (string? (first opts)))
-     (eastwood-from-cmdline (edn/read-string (first opts)))
-     (let [parsed (->> opts (interpose " ") (apply str) edn/read-string)]
-       (eastwood-from-cmdline parsed)))))
+   (let [reducer #(merge %1 (if (string? %2)
+                              (edn/read-string %2)
+                              %2))
+         parsed (reduce reducer default-opts opts)]
+     (eastwood-from-cmdline parsed))))


### PR DESCRIPTION
Currently eastwood doesn't correctly parse command line arguments if there is already a configuration in `deps.edn`.  For example if we have this in ours `deps.edn`: 
```
{:aliases {:eastwood
           {:main-opts ["-m" "eastwood.lint" {}]
            :extra-deps {jonase/eastwood {:mvn/version "1.2.3"}}}}}
```

Then running `clojure -M:eastwood "{:namespaces [user]}"` won't check only the `user` namespace.  

This PR allows the opts to be a list of any combination of maps or strings and merges them with the default opts to be passed to `eastwood.lint/eastwood-from-cmdline`

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):


- [ ] You've updated the [changelog](../blob/master/changes.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [readme](../blob/master/README.md) (if eg adding a new linter)

Thanks!
